### PR TITLE
feat: add Make webhook triggers

### DIFF
--- a/api/make/test-trigger.js
+++ b/api/make/test-trigger.js
@@ -1,0 +1,3 @@
+import { testTriggerHandler } from "../../handlers/testTriggerHandler.js";
+
+export default testTriggerHandler;

--- a/api/make/trigger-scenario.js
+++ b/api/make/trigger-scenario.js
@@ -1,0 +1,3 @@
+import { triggerScenarioHandler } from "../../handlers/triggerScenarioHandler.js";
+
+export default triggerScenarioHandler;

--- a/constants/make.js
+++ b/constants/make.js
@@ -1,0 +1,1 @@
+export const DEFAULT_MAKE_API_TOKEN = "44d53bf9-799a-4e41-8b2f-3585fa2b7bfd";

--- a/handlers/testTriggerHandler.js
+++ b/handlers/testTriggerHandler.js
@@ -1,0 +1,115 @@
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+import { postToWebhook } from "../helpers/postToWebhook.js";
+
+export async function testTriggerHandler(req, res) {
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/test-trigger",
+      action: "methodCheck",
+      status: 405,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/test-trigger",
+      action: "keyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { webhook_url, payload, requester } = req.body || {};
+
+  if (!webhook_url || !payload) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/test-trigger",
+      action: "validation",
+      status: 400,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Missing webhook_url or payload"
+    }));
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing webhook_url or payload",
+      error: "Missing webhook_url or payload",
+      nextStep: "Provide webhook_url and payload"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/test-trigger",
+      action: "blockedRequester",
+      status: 403,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Requester is blocked"
+    }));
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    const data = await postToWebhook(webhook_url, payload);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/test-trigger",
+      action: "success",
+      status: 200,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      summary: "Webhook triggered"
+    }));
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Webhook triggered",
+      data
+    });
+  } catch (error) {
+    console.error("Error triggering webhook:", error);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/test-trigger",
+      action: "error",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Internal Server Error"
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}

--- a/handlers/triggerScenarioHandler.js
+++ b/handlers/triggerScenarioHandler.js
@@ -1,0 +1,115 @@
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+import { postToWebhook } from "../helpers/postToWebhook.js";
+
+export async function triggerScenarioHandler(req, res) {
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/trigger-scenario",
+      action: "methodCheck",
+      status: 405,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/trigger-scenario",
+      action: "keyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { scenario_id, webhook_url, payload, requester } = req.body || {};
+
+  if (!scenario_id || !webhook_url || !payload) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/trigger-scenario",
+      action: "validation",
+      status: 400,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Missing scenario_id, webhook_url, or payload"
+    }));
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing scenario_id, webhook_url, or payload",
+      error: "Missing scenario_id, webhook_url, or payload",
+      nextStep: "Provide scenario_id, webhook_url, and payload"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/trigger-scenario",
+      action: "blockedRequester",
+      status: 403,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Requester is blocked"
+    }));
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    const data = await postToWebhook(webhook_url, payload);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/trigger-scenario",
+      action: "success",
+      status: 200,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      summary: "Scenario triggered"
+    }));
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Scenario triggered",
+      data
+    });
+  } catch (error) {
+    console.error("Error triggering scenario:", error);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/trigger-scenario",
+      action: "error",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Internal Server Error"
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}

--- a/helpers/postToWebhook.js
+++ b/helpers/postToWebhook.js
@@ -1,0 +1,19 @@
+import { DEFAULT_MAKE_API_TOKEN } from "../constants/make.js";
+
+export async function postToWebhook(url, payload) {
+  const token = process.env.MAKE_API_TOKEN || DEFAULT_MAKE_API_TOKEN;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}

--- a/tests/testTriggerHandler.test.js
+++ b/tests/testTriggerHandler.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { testTriggerHandler } from "../handlers/testTriggerHandler.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.MAKE_API_TOKEN = "make-test";
+});
+
+describe("testTriggerHandler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await testTriggerHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 400 when fields missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await testTriggerHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 200 on success", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ json: () => Promise.resolve({ result: "ok" }) });
+    const req = httpMocks.createRequest({ method: "POST", body: { webhook_url: "url", payload: {} } });
+    const res = httpMocks.createResponse();
+    await testTriggerHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).success).toBe(true);
+  });
+});

--- a/tests/triggerScenarioHandler.test.js
+++ b/tests/triggerScenarioHandler.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { triggerScenarioHandler } from "../handlers/triggerScenarioHandler.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.MAKE_API_TOKEN = "make-test";
+});
+
+describe("triggerScenarioHandler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await triggerScenarioHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST", body: { scenario_id: "1", webhook_url: "url", payload: {} } });
+    const res = httpMocks.createResponse();
+    await triggerScenarioHandler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when fields missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await triggerScenarioHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { scenario_id: "1", webhook_url: "url", payload: {}, requester: "Ruslantara" } });
+    const res = httpMocks.createResponse();
+    await triggerScenarioHandler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 200 on success", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ json: () => Promise.resolve({ result: "ok" }) });
+    const req = httpMocks.createRequest({ method: "POST", body: { scenario_id: "1", webhook_url: "url", payload: {} } });
+    const res = httpMocks.createResponse();
+    await triggerScenarioHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- support triggering Make scenarios via new `/make/trigger-scenario` endpoint
- add `/make/test-trigger` endpoint for webhook testing
- provide helper and tests for Make webhook posting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f93b3ca948330b7ccf9ec69635ebb