### PR TITLE
feat: orchestrate agents via zantara endpoint

### DIFF
--- a/api/zantara.js
+++ b/api/zantara.js
@@ -1,3 +1,160 @@
-import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
 
-export default createAgentHandler("Zantara");
+const agents = [
+  "antonelloDaily",
+  "baliZeroHub",
+  "morgana",
+  "setupMaster",
+  "taxGenius",
+  "theLegalArchitect",
+  "visaOracle"
+];
+
+export default async function handler(req, res) {
+  const route = "/api/zantara";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
+
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "methodCheck",
+        status: 405,
+        userIP,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "keyValidation",
+        status: 500,
+        userIP,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { prompt, requester } = req.body || {};
+
+  if (!prompt) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "promptValidation",
+        status: 400,
+        userIP,
+        message: "Missing prompt in request body"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing prompt in request body",
+      error: "Missing prompt in request body",
+      nextStep: "Include prompt in JSON body"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "blockedRequester",
+        status: 403,
+        userIP,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    const baseUrl = process.env.BASE_URL || `http://${req.headers.host}`;
+    const results = {};
+
+    for (const agent of agents) {
+      try {
+        const response = await fetch(`${baseUrl}/api/${agent}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ prompt, requester })
+        });
+        results[agent] = await response.json();
+      } catch (err) {
+        results[agent] = {
+          success: false,
+          status: 500,
+          summary: "Agent call failed",
+          error: "Agent call failed"
+        };
+      }
+    }
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "orchestrate",
+        status: 200,
+        userIP,
+        summary: "All agents executed"
+      })
+    );
+
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "All agents executed",
+      data: results
+    });
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "error",
+        status: 500,
+        userIP,
+        message: "Internal Server Error"
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}
+

--- a/tests/zantara.test.js
+++ b/tests/zantara.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/zantara.js";
+
+const agents = [
+  "antonelloDaily",
+  "baliZeroHub",
+  "morgana",
+  "setupMaster",
+  "taxGenius",
+  "theLegalArchitect",
+  "visaOracle"
+];
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.BASE_URL = "http://localhost";
+  vi.resetAllMocks();
+});
+
+describe("Zantara orchestrator", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when prompt missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi", requester: "Ruslantara" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 200 on success and aggregates results", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ success: true })
+    });
+
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi", requester: "user" } });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+    expect(Object.keys(data.data)).toEqual(agents);
+    expect(global.fetch).toHaveBeenCalledTimes(agents.length);
+  });
+});
+


### PR DESCRIPTION
## Summary
- implement Zantara as orchestrator calling seven agent endpoints
- validate requests and aggregate agent responses
- cover orchestrator behavior with vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fadb3f26883308a7b4ec9a5653e55