### PR TITLE
feat: add Make webhook trigger utility

### DIFF
--- a/lib/makeTrigger.js
+++ b/lib/makeTrigger.js
@@ -1,0 +1,45 @@
+import { DEFAULT_MAKE_API_TOKEN } from "../constants/make.js";
+
+/**
+ * Trigger a Make webhook with optional payload.
+ * @param {Object} data Optional data to send in request body
+ * @returns {Promise<Object>} Parsed JSON response or empty object
+ */
+export async function triggerMakeWebhook(data = {}) {
+  const url = process.env.MAKE_WEBHOOK_URL || "https://example.com";
+  const token = process.env.MAKE_API_TOKEN || DEFAULT_MAKE_API_TOKEN;
+  const payload = Object.keys(data).length ? data : { module: "Zantara", status: "ACTIVE" };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      action: "makeWebhookError",
+      status: response.status,
+      message
+    }));
+    throw new Error("Make webhook error");
+  }
+
+  try {
+    const result = await response.json();
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      action: "makeWebhookTriggered",
+      status: response.status
+    }));
+    return result;
+  } catch {
+    return {};
+  }
+}
+

--- a/tests/makeTrigger.test.js
+++ b/tests/makeTrigger.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { triggerMakeWebhook } from "../lib/makeTrigger.js";
+
+describe("ZANTARA > triggerMakeWebhook", () => {
+  it("should send default payload to Make webhook", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    const result = await triggerMakeWebhook();
+    expect(result).toBeDefined(); // may be empty object
+  });
+
+  it("should send custom data in payload", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    const result = await triggerMakeWebhook({
+      module: "UnitTest",
+      status: "OK",
+    });
+    expect(result).toBeDefined();
+  });
+
+  it("should throw an error for invalid URL", async () => {
+    // Override temporarily
+    const originalURL = global.fetch;
+    global.fetch = () => Promise.resolve({ ok: false, status: 400, text: () => "Bad Request" });
+
+    await expect(triggerMakeWebhook()).rejects.toThrow("Make webhook error");
+
+    global.fetch = originalURL;
+  });
+});
+


### PR DESCRIPTION
## Summary
- add triggerMakeWebhook helper for Make.com integration
- cover Make webhook calls with Vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fa3721db08330864308ab7ba10c2c