### PR TITLE
feat: add meeting sync API endpoint

### DIFF
--- a/api/make/meeting-sync.js
+++ b/api/make/meeting-sync.js
@@ -1,0 +1,3 @@
+import { meetingSyncHandler } from "../../handlers/meetingSyncHandler.js";
+
+export default meetingSyncHandler;

--- a/constants/make.js
+++ b/constants/make.js
@@ -1,1 +1,2 @@
 export const DEFAULT_MAKE_API_TOKEN = "44d53bf9-799a-4e41-8b2f-3585fa2b7bfd";
+export const MEETING_SYNC_WEBHOOK_URL = "https://example.com";

--- a/handlers/meetingSyncHandler.js
+++ b/handlers/meetingSyncHandler.js
@@ -1,0 +1,120 @@
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+import { postToWebhook } from "../helpers/postToWebhook.js";
+import { MEETING_SYNC_WEBHOOK_URL } from "../constants/make.js";
+
+export async function meetingSyncHandler(req, res) {
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/meeting-sync",
+      action: "methodCheck",
+      status: 405,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/meeting-sync",
+      action: "keyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { title, datetimeStart, datetimeEnd, description, requester } = req.body || {};
+
+  if (!title || !datetimeStart || !datetimeEnd || !description) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/meeting-sync",
+      action: "validation",
+      status: 400,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Missing title, datetimeStart, datetimeEnd, or description"
+    }));
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing title, datetimeStart, datetimeEnd, or description",
+      error: "Missing title, datetimeStart, datetimeEnd, or description",
+      nextStep: "Provide title, datetimeStart, datetimeEnd, and description"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/meeting-sync",
+      action: "blockedRequester",
+      status: 403,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Requester is blocked"
+    }));
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  const webhookUrl = process.env.MEETING_SYNC_WEBHOOK_URL || MEETING_SYNC_WEBHOOK_URL;
+  const payload = { title, datetimeStart, datetimeEnd, description };
+
+  try {
+    const data = await postToWebhook(webhookUrl, payload);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/meeting-sync",
+      action: "success",
+      status: 200,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      summary: "Meeting synced"
+    }));
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Meeting synced",
+      data
+    });
+  } catch (error) {
+    console.error("Error syncing meeting:", error);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/meeting-sync",
+      action: "error",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Internal Server Error"
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}
+

--- a/tests/meetingSyncHandler.test.js
+++ b/tests/meetingSyncHandler.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { meetingSyncHandler } from "../handlers/meetingSyncHandler.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.MAKE_API_TOKEN = "make-test";
+  process.env.MEETING_SYNC_WEBHOOK_URL = "https://example.com";
+});
+
+describe("meetingSyncHandler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await meetingSyncHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 400 when fields missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await meetingSyncHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { title: "t", datetimeStart: "a", datetimeEnd: "b", description: "d", requester: "Ruslantara" } });
+    const res = httpMocks.createResponse();
+    await meetingSyncHandler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 200 on success", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ json: () => Promise.resolve({ result: "ok" }) });
+    const req = httpMocks.createRequest({ method: "POST", body: { title: "Call", datetimeStart: "2025-08-05T14:00:00+08:00", datetimeEnd: "2025-08-05T14:30:00+08:00", description: "Discuss" } });
+    const res = httpMocks.createResponse();
+    await meetingSyncHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add Make meeting sync webhook constant
- create meeting sync API route and handler to forward meeting details to Make
- test meeting sync handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fdafe6a488330be21bda816dc424d