### PR TITLE
feat: add Gmail email endpoint

### DIFF
--- a/api/zion/email.js
+++ b/api/zion/email.js
@@ -1,0 +1,117 @@
+/* Send email through Gmail */
+import { validateOpenAIKey } from "../../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../../helpers/checkBlockedRequester.js";
+import { sendEmail } from "../../helpers/sendEmail.js";
+
+export default async function handler(req, res) {
+  const route = "/api/zion/email";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
+
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "methodCheck",
+      status: 405,
+      userIP,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "keyValidation",
+      status: 500,
+      userIP,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { ACTION, TO, TEXT, requester } = req.body || {};
+
+  if (!ACTION || !TO || !TEXT) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "payloadValidation",
+      status: 400,
+      userIP,
+      message: "Missing ACTION, TO, or TEXT"
+    }));
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing ACTION, TO, or TEXT",
+      error: "Missing ACTION, TO, or TEXT",
+      nextStep: "Provide ACTION, TO, and TEXT"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "blockedRequester",
+      status: 403,
+      userIP,
+      message: "Requester is blocked"
+    }));
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    await sendEmail({ action: ACTION, to: TO, text: TEXT });
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: ACTION,
+      status: 200,
+      userIP,
+      summary: "Email sent"
+    }));
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Email sent",
+      data: { message: "Email dispatched" }
+    });
+  } catch (error) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: ACTION,
+      status: 500,
+      userIP,
+      message: error.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Email send failed",
+      error: "Email send failed"
+    });
+  }
+}

--- a/helpers/sendEmail.js
+++ b/helpers/sendEmail.js
@@ -1,0 +1,23 @@
+/* Send email using Gmail credentials */
+import nodemailer from "nodemailer";
+
+export async function sendEmail({ action, to, text }) {
+  if (!process.env.GMAIL_USER || !process.env.GMAIL_PASS) {
+    throw new Error("Missing Gmail credentials");
+  }
+
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      user: process.env.GMAIL_USER,
+      pass: process.env.GMAIL_PASS
+    }
+  });
+
+  await transporter.sendMail({
+    from: process.env.GMAIL_USER,
+    to,
+    subject: action || "Notification",
+    text
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "zantara-api",
       "version": "1.0.0",
+      "dependencies": {
+        "nodemailer": "^6.10.1"
+      },
       "devDependencies": {
         "node-mocks-http": "^1.11.0",
         "vitest": "^1.0.0"
@@ -1351,6 +1354,15 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "devDependencies": {
     "node-mocks-http": "^1.11.0",
     "vitest": "^1.0.0"
+  },
+  "dependencies": {
+    "nodemailer": "^6.10.1"
   }
 }

--- a/tests/sendEmail.test.js
+++ b/tests/sendEmail.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { sendEmail } from "../helpers/sendEmail.js";
+
+vi.mock("nodemailer", () => ({
+  default: {
+    createTransport: vi.fn().mockReturnValue({
+      sendMail: vi.fn().mockResolvedValue(true)
+    })
+  }
+}));
+
+describe("sendEmail", () => {
+  beforeEach(() => {
+    process.env.GMAIL_USER = "user@gmail.com";
+    process.env.GMAIL_PASS = "pass";
+  });
+
+  it("sends email when credentials exist", async () => {
+    await expect(sendEmail({ action: "Test", to: "a@b.com", text: "Hello" })).resolves.not.toThrow();
+  });
+
+  it("throws when credentials missing", async () => {
+    delete process.env.GMAIL_USER;
+    await expect(sendEmail({ action: "Test", to: "a@b.com", text: "Hello" })).rejects.toThrow(
+      "Missing Gmail credentials"
+    );
+  });
+});

--- a/tests/zionEmail.test.js
+++ b/tests/zionEmail.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/zion/email.js";
+import { sendEmail } from "../helpers/sendEmail.js";
+
+vi.mock("../helpers/sendEmail.js", () => ({
+  sendEmail: vi.fn()
+}));
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.GMAIL_USER = "user";
+  process.env.GMAIL_PASS = "pass";
+  sendEmail.mockResolvedValue();
+});
+
+describe("/api/zion/email", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST", body: { ACTION: "Test", TO: "a@b.com", TEXT: "Hello" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when payload missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: {} });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { ACTION: "Test", TO: "a@b.com", TEXT: "Hello", requester: "Ruslantara" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 200 on success", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { ACTION: "Test", TO: "a@b.com", TEXT: "Hello" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add /api/zion/email endpoint to send Gmail messages
- implement sendEmail helper using Nodemailer
- add unit tests for email helper and endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f77cb75348330b6ffdcf5dcc4e34c