### PR TITLE
feat: add Zion email endpoint

### DIFF
--- a/api/zion/email.js
+++ b/api/zion/email.js
@@ -1,0 +1,3 @@
+import { sendEmailHandler } from "../../handlers/sendEmailHandler.js";
+
+export default sendEmailHandler;

--- a/handlers/sendEmailHandler.js
+++ b/handlers/sendEmailHandler.js
@@ -1,0 +1,129 @@
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+import { sendEmail } from "../helpers/sendEmail.js";
+
+export async function sendEmailHandler(req, res) {
+  const route = "/api/zion/email";
+
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "methodCheck",
+        status: 405,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "keyValidation",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { to, subject, text, requester } = req.body || {};
+
+  if (!to || !subject || !text) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "validation",
+        status: 400,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Missing to, subject, or text"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing to, subject, or text",
+      error: "Missing to, subject, or text",
+      nextStep: "Provide to, subject, and text"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "blockedRequester",
+        status: 403,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    await sendEmail(to, subject, text);
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "success",
+        status: 200,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        summary: "Email sent"
+      })
+    );
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Email sent",
+      data: { to }
+    });
+  } catch (error) {
+    console.error("Error sending email:", error);
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "error",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Internal Server Error"
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}

--- a/helpers/sendEmail.js
+++ b/helpers/sendEmail.js
@@ -1,0 +1,22 @@
+import nodemailer from "nodemailer";
+
+export async function sendEmail(to, subject, text) {
+  if (!process.env.GMAIL_USER || !process.env.GMAIL_PASS) {
+    throw new Error("Missing Gmail credentials");
+  }
+
+  const transporter = nodemailer.createTransport({
+    service: "gmail",
+    auth: {
+      user: process.env.GMAIL_USER,
+      pass: process.env.GMAIL_PASS
+    }
+  });
+
+  await transporter.sendMail({
+    from: process.env.GMAIL_USER,
+    to,
+    subject,
+    text
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "zantara-api",
       "version": "1.0.0",
+      "dependencies": {
+        "nodemailer": "^6.9.8"
+      },
       "devDependencies": {
         "node-mocks-http": "^1.11.0",
         "vitest": "^1.0.0"
@@ -1351,6 +1354,15 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "test": "vitest run"
   },
+  "dependencies": {
+    "nodemailer": "^6.9.8"
+  },
   "devDependencies": {
     "node-mocks-http": "^1.11.0",
     "vitest": "^1.0.0"

--- a/tests/sendEmailHandler.test.js
+++ b/tests/sendEmailHandler.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { sendEmailHandler } from "../handlers/sendEmailHandler.js";
+
+vi.mock("../helpers/sendEmail.js", () => ({
+  sendEmail: vi.fn().mockResolvedValue()
+}));
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.GMAIL_USER = "user";
+  process.env.GMAIL_PASS = "pass";
+});
+
+describe("sendEmailHandler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await sendEmailHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST", body: { to: "a", subject: "b", text: "c" } });
+    const res = httpMocks.createResponse();
+    await sendEmailHandler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when fields missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { to: "a" } });
+    const res = httpMocks.createResponse();
+    await sendEmailHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { to: "a", subject: "b", text: "c", requester: "Ruslantara" } });
+    const res = httpMocks.createResponse();
+    await sendEmailHandler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 200 on success", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { to: "a", subject: "b", text: "c" } });
+    const res = httpMocks.createResponse();
+    await sendEmailHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add nodemailer dependency
- implement sendEmail helper and handler for /api/zion/email
- expose new endpoint and cover with vitest unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68903d01a4308330a45e52d7999a3e06