### PR TITLE
test: add Notion client tests

### DIFF
--- a/lib/notionClient.js
+++ b/lib/notionClient.js
@@ -1,0 +1,52 @@
+import { Client } from "@notionhq/client";
+
+/**
+ * Return a Notion client instance using NOTION_API_KEY.
+ * @returns {Client}
+ * @throws {Error} when NOTION_API_KEY missing
+ */
+export function getNotionClient() {
+  const apiKey = process.env.NOTION_API_KEY;
+  if (!apiKey) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      action: "missingNotionKey"
+    }));
+    throw new Error("Missing Notion API Key");
+  }
+  return new Client({ auth: apiKey });
+}
+
+/**
+ * Save agent output to a Notion database.
+ * @param {Object} params
+ * @param {string} params.databaseId Notion database ID
+ * @param {string} params.agent Agent identifier
+ * @param {string} params.output Output content
+ */
+export async function saveAgentOutput({ databaseId, agent, output }) {
+  const client = getNotionClient();
+  const payload = {
+    parent: { database_id: databaseId },
+    properties: {
+      Agent: { title: [{ text: { content: agent } }] },
+      Output: { rich_text: [{ text: { content: output } }] }
+    }
+  };
+  try {
+    await client.pages.create(payload);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      action: "notionPageCreated",
+      databaseId
+    }));
+  } catch (error) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      action: "notionPageError",
+      message: error.message
+    }));
+    throw error;
+  }
+}
+

--- a/tests/notionClient.test.js
+++ b/tests/notionClient.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe("notionClient", () => {
+  it("getNotionClient throws without NOTION_API_KEY", async () => {
+    vi.doMock("@notionhq/client", () => ({ Client: vi.fn() }));
+    delete process.env.NOTION_API_KEY;
+    const { getNotionClient } = await import("../lib/notionClient.js");
+    expect(() => getNotionClient()).toThrow("Missing Notion API Key");
+  });
+
+  it("saveAgentOutput calls pages.create with expected payload", async () => {
+    process.env.NOTION_API_KEY = "test";
+    const createMock = vi.fn().mockResolvedValue({});
+    vi.doMock("@notionhq/client", () => ({
+      Client: vi.fn(() => ({ pages: { create: createMock } }))
+    }));
+    const { saveAgentOutput } = await import("../lib/notionClient.js");
+    await saveAgentOutput({ databaseId: "db123", agent: "Agent", output: "Hello" });
+    expect(createMock).toHaveBeenCalledWith({
+      parent: { database_id: "db123" },
+      properties: {
+        Agent: { title: [{ text: { content: "Agent" } }] },
+        Output: { rich_text: [{ text: { content: "Hello" } }] }
+      }
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add helper for creating a Notion client and saving agent output
- cover getNotionClient and saveAgentOutput with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68909769892c8330893c2b1d3a480c5b