### PR TITLE
feat: log agent output to notion

### DIFF
--- a/handlers/createAgentHandler.js
+++ b/handlers/createAgentHandler.js
@@ -1,6 +1,7 @@
 import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
 import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
 import { getAgentPrompt } from "../constants/prompts.js";
+import { saveAgentOutput } from "../helpers/notionClient.js";
 
 export function createAgentHandler(agentName) {
   return async function handler(req, res) {
@@ -98,6 +99,20 @@ export function createAgentHandler(agentName) {
       });
 
       const data = await response.json();
+
+      const responseText = data.choices?.[0]?.message?.content || "";
+      try {
+        await saveAgentOutput(process.env.NOTION_DATABASE_ID, agentName, prompt, responseText);
+      } catch (err) {
+        console.log(JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route: `/api/${agentName}`,
+          action: "notionError",
+          status: 500,
+          userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+          message: err.message
+        }));
+      }
 
       console.log(JSON.stringify({
         timestamp: new Date().toISOString(),

--- a/helpers/notionClient.js
+++ b/helpers/notionClient.js
@@ -1,0 +1,26 @@
+export async function saveAgentOutput(databaseId, agentName, prompt, responseText) {
+  const notionKey = process.env.NOTION_API_KEY;
+  if (!notionKey) {
+    throw new Error("Missing Notion API Key");
+  }
+  if (!databaseId) {
+    throw new Error("Missing Notion Database ID");
+  }
+
+  await fetch("https://api.notion.com/v1/pages", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${notionKey}`,
+      "Content-Type": "application/json",
+      "Notion-Version": "2022-06-28"
+    },
+    body: JSON.stringify({
+      parent: { database_id: databaseId },
+      properties: {
+        Agent: { title: [{ text: { content: agentName } }] },
+        Prompt: { rich_text: [{ text: { content: prompt } }] },
+        Response: { rich_text: [{ text: { content: responseText } }] }
+      }
+    })
+  });
+}

--- a/tests/notionClient.test.js
+++ b/tests/notionClient.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { saveAgentOutput } from "../helpers/notionClient.js";
+
+describe("saveAgentOutput", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    delete process.env.NOTION_API_KEY;
+  });
+
+  it("throws when Notion API Key missing", async () => {
+    await expect(saveAgentOutput("db", "agent", "prompt", "response"))
+      .rejects.toThrow("Missing Notion API Key");
+  });
+
+  it("calls Notion API when configured", async () => {
+    process.env.NOTION_API_KEY = "key";
+    global.fetch = vi.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    await saveAgentOutput("db", "agent", "prompt", "response");
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.notion.com/v1/pages",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+});

--- a/tests/zantara.test.js
+++ b/tests/zantara.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import httpMocks from "node-mocks-http";
+
+vi.mock("../helpers/notionClient.js", () => ({
+  saveAgentOutput: vi.fn().mockResolvedValue()
+}));
+
 import handler from "../api/zantara.js";
 
 const agents = [
@@ -9,7 +14,7 @@ const agents = [
   "setupMaster",
   "taxGenius",
   "theLegalArchitect",
-  "visaOracle"
+  "visaOracle",
 ];
 
 beforeEach(() => {
@@ -65,4 +70,3 @@ describe("Zantara orchestrator", () => {
     expect(global.fetch).toHaveBeenCalledTimes(agents.length);
   });
 });
-


### PR DESCRIPTION
## Summary
- log OpenAI responses to Notion for each agent
- add Notion client helper and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68909767e014833093d8a2f9f68f9394