### PR TITLE
Add Notion bridge connector and API handler

### DIFF
--- a/api/notion-bridge.js
+++ b/api/notion-bridge.js
@@ -1,0 +1,123 @@
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+import { sendNotionUpdate } from "../helpers/notionBridge.js";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion-bridge",
+        action: "methodCheck",
+        status: 405,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion-bridge",
+        action: "keyValidation",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { request, summary, requester } = req.body || {};
+
+  if (!request || !summary || !requester) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion-bridge",
+        action: "bodyValidation",
+        status: 400,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Missing required fields"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing required fields",
+      error: "Missing required fields",
+      nextStep: "Include request, summary and requester"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion-bridge",
+        action: "blockedRequester",
+        status: 403,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    const result = await sendNotionUpdate({ request, summary });
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion-bridge",
+        action: "forwardRequest",
+        status: result.status,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        success: result.success
+      })
+    );
+
+    return res.status(result.status).json(result);
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion-bridge",
+        action: "error",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: error.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}

--- a/helpers/notionBridge.js
+++ b/helpers/notionBridge.js
@@ -1,0 +1,69 @@
+export async function sendNotionUpdate({ request, summary }) {
+  const url = process.env.NOTION_WRITE_URL || "https://zantara.vercel.app/api/notion-write";
+
+  console.log(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "helpers/notionBridge",
+      action: "start",
+      status: 0,
+      summary,
+      request
+    })
+  );
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ request, summary })
+    });
+
+    const data = await response.json().catch(() => ({}));
+    const success = response.ok;
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "helpers/notionBridge",
+        action: "response",
+        status: response.status,
+        success
+      })
+    );
+
+    if (!success) {
+      return {
+        success: false,
+        status: response.status,
+        summary: "Failed to update Notion",
+        error: data.error || "Request failed"
+      };
+    }
+
+    return {
+      success: true,
+      status: response.status,
+      summary: "Notion updated",
+      data
+    };
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "helpers/notionBridge",
+        action: "error",
+        status: 500,
+        message: error.message
+      })
+    );
+    return {
+      success: false,
+      status: 500,
+      summary: "Internal Error",
+      error: error.message
+    };
+  }
+}

--- a/pages/api/webhooks/meta/whatsapp.js
+++ b/pages/api/webhooks/meta/whatsapp.js
@@ -1,0 +1,101 @@
+import { validateOpenAIKey } from "../../../../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../../../../helpers/checkBlockedRequester.js";
+
+export default async function handler(req, res) {
+  if (req.method === "GET") {
+    const challenge = req.query["hub.challenge"];
+    if (challenge) {
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route: "/pages/api/webhooks/meta/whatsapp",
+          action: "challenge",
+          status: 200,
+          userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress
+        })
+      );
+      return res.status(200).send(challenge);
+    }
+    return res.status(400).send("Missing challenge");
+  }
+
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/pages/api/webhooks/meta/whatsapp",
+        action: "methodCheck",
+        status: 405,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Use GET or POST"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/pages/api/webhooks/meta/whatsapp",
+        action: "keyValidation",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { requester } = req.body || {};
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/pages/api/webhooks/meta/whatsapp",
+        action: "blockedRequester",
+        status: 403,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  console.log(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/pages/api/webhooks/meta/whatsapp",
+      action: "success",
+      status: 200,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      summary: "Request accepted"
+    })
+  );
+
+  return res.status(200).json({
+    success: true,
+    status: 200,
+    summary: "Request accepted"
+  });
+}

--- a/tests/notionBridgeHandler.test.js
+++ b/tests/notionBridgeHandler.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/notion-bridge.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+});
+
+describe("notion-bridge handler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 400 when body fields missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { summary: "sum" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { request: "hi", summary: "sum", requester: "Ruslantara" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { request: "hi", summary: "sum", requester: "me" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 200 on success", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ result: "ok" })
+    });
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { request: "hi", summary: "sum", requester: "me" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add helper to forward Notion write requests to Vercel with structured logging
- Create `/api/notion-bridge` handler that validates requests and sends data via helper
- Introduce unit tests for Notion bridge handler and restore missing WhatsApp webhook handler for test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ae51939c88330a2454d377f62c5b1