### PR TITLE
feat: add idempotent WhatsApp webhook

### DIFF
--- a/api/whatsapp/webhook.js
+++ b/api/whatsapp/webhook.js
@@ -1,22 +1,186 @@
-export default function handler(req, res) {
+import { validateOpenAIKey } from "../../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../../helpers/checkBlockedRequester.js";
+const processedEvents = new Set();
+
+export default async function handler(req, res) {
+  const route = "/api/whatsapp/webhook";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
   const VERIFY_TOKEN = process.env.ZANTARA_WHATSAPP_TOKEN || "ZANTARA_WHATSAPP_TOKEN";
 
   if (req.method === "GET") {
     const mode = req.query["hub.mode"];
     const token = req.query["hub.verify_token"];
     const challenge = req.query["hub.challenge"];
+
     if (mode === "subscribe" && token === VERIFY_TOKEN && challenge) {
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route,
+          action: "verify",
+          status: 200,
+          userIP,
+        })
+      );
       res.setHeader("Content-Type", "text/plain");
       return res.status(200).send(challenge);
     }
+
+    if (mode === "subscribe" && token === VERIFY_TOKEN && !challenge) {
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route,
+          action: "verify",
+          status: 400,
+          userIP,
+          message: "Missing challenge",
+        })
+      );
+      return res.status(400).json({
+        success: false,
+        status: 400,
+        summary: "Missing challenge",
+        error: "Missing challenge",
+      });
+    }
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "verify",
+        status: 403,
+        userIP,
+        message: "Invalid token",
+      })
+    );
     return res.sendStatus(403);
   }
 
-  if (req.method === "POST") {
-    console.log("WhatsApp incoming:", JSON.stringify(req.body || {}, null, 2));
-    return res.sendStatus(200);
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "methodCheck",
+        status: 405,
+        userIP,
+        message: "Method Not Allowed",
+      })
+    );
+    res.setHeader("Allow", ["GET", "POST"]);
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Use POST",
+    });
   }
 
-  res.setHeader("Allow", ["GET", "POST"]);
-  res.status(405).end(`Method ${req.method} Not Allowed`);
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "keyValidation",
+        status: 500,
+        userIP,
+        message: err.message,
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment",
+    });
+  }
+
+  try {
+    const { requester, entry } = req.body || {};
+
+    if (isBlockedRequester(requester)) {
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route,
+          action: "blockedRequester",
+          status: 403,
+          userIP,
+          message: "Requester is blocked",
+        })
+      );
+      return res.status(403).json({
+        success: false,
+        status: 403,
+        summary: "Requester is blocked",
+        error: "Access denied",
+      });
+    }
+
+    const ids = [];
+    if (Array.isArray(entry)) {
+      for (const ent of entry) {
+        const changes = ent?.changes || [];
+        for (const change of changes) {
+          const messages = change?.value?.messages || [];
+          for (const msg of messages) {
+            if (msg.id) ids.push(msg.id);
+          }
+        }
+      }
+    }
+
+    let summary;
+    let newCount = 0;
+    for (const id of ids) {
+      if (!processedEvents.has(id)) {
+        processedEvents.add(id);
+        newCount++;
+      }
+    }
+
+    if (!ids.length) {
+      summary = "No messages";
+    } else if (newCount) {
+      summary = "Event processed";
+    } else {
+      summary = "Event already processed";
+    }
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "process",
+        status: 200,
+        userIP,
+        summary,
+      })
+    );
+
+    return res.status(200).json({ success: true, status: 200, summary });
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "process",
+        status: 500,
+        userIP,
+        message: err.message,
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+    });
+  }
 }

--- a/tests/whatsappWebhook.test.js
+++ b/tests/whatsappWebhook.test.js
@@ -1,16 +1,21 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import httpMocks from "node-mocks-http";
-import handler from "../pages/api/webhooks/meta/whatsapp.js";
+import handler from "../api/whatsapp/webhook.js";
 
 beforeEach(() => {
   process.env.OPENAI_API_KEY = "test";
+  process.env.ZANTARA_WHATSAPP_TOKEN = "token";
 });
 
 describe("whatsapp webhook", () => {
   it("returns challenge for GET", async () => {
     const req = httpMocks.createRequest({
       method: "GET",
-      query: { "hub.challenge": "1234" }
+      query: {
+        "hub.mode": "subscribe",
+        "hub.verify_token": "token",
+        "hub.challenge": "1234",
+      },
     });
     const res = httpMocks.createResponse();
     await handler(req, res);
@@ -27,7 +32,7 @@ describe("whatsapp webhook", () => {
 
   it("returns 500 when API key missing", async () => {
     delete process.env.OPENAI_API_KEY;
-    const req = httpMocks.createRequest({ method: "POST" });
+    const req = httpMocks.createRequest({ method: "POST", body: {} });
     const res = httpMocks.createResponse();
     await handler(req, res);
     expect(res.statusCode).toBe(500);
@@ -36,19 +41,46 @@ describe("whatsapp webhook", () => {
   it("blocks specified requester", async () => {
     const req = httpMocks.createRequest({
       method: "POST",
-      body: { requester: "Ruslantara" }
+      body: { requester: "Ruslantara" },
     });
     const res = httpMocks.createResponse();
     await handler(req, res);
     expect(res.statusCode).toBe(403);
   });
 
-  it("returns 200 on valid POST", async () => {
-    const req = httpMocks.createRequest({ method: "POST", body: {} });
-    const res = httpMocks.createResponse();
-    await handler(req, res);
-    expect(res.statusCode).toBe(200);
-    const data = JSON.parse(res._getData());
-    expect(data.success).toBe(true);
+  it("handles Meta payload idempotently", async () => {
+    const metaPayload = {
+      entry: [
+        {
+          changes: [
+            {
+              value: {
+                messages: [
+                  {
+                    id: "wamid.ABCD",
+                    text: { body: "hi" },
+                    type: "text",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const req1 = httpMocks.createRequest({ method: "POST", body: metaPayload });
+    const res1 = httpMocks.createResponse();
+    await handler(req1, res1);
+    expect(res1.statusCode).toBe(200);
+    const data1 = JSON.parse(res1._getData());
+    expect(data1.summary).toBe("Event processed");
+
+    const req2 = httpMocks.createRequest({ method: "POST", body: metaPayload });
+    const res2 = httpMocks.createResponse();
+    await handler(req2, res2);
+    expect(res2.statusCode).toBe(200);
+    const data2 = JSON.parse(res2._getData());
+    expect(data2.summary).toBe("Event already processed");
   });
 });


### PR DESCRIPTION
## Summary
- add structured WhatsApp webhook handler with token validation and idempotent event capture
- test Meta-style payload processing and blocked requesters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c50557c148330a7e0c4f66c205d9d