### PR TITLE
feat: add whatsapp send endpoint

### DIFF
--- a/api/whatsapp/send.js
+++ b/api/whatsapp/send.js
@@ -1,0 +1,189 @@
+import { validateOpenAIKey } from "../../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../../helpers/checkBlockedRequester.js";
+
+export default async function handler(req, res) {
+  const route = "/api/whatsapp/send";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
+
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "methodCheck",
+        status: 405,
+        userIP,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "keyValidation",
+        status: 500,
+        userIP,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { to, message, requester } = req.body || {};
+
+  if (!to || !message) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "bodyValidation",
+        status: 400,
+        userIP,
+        message: "Missing required fields"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing required fields",
+      error: "Missing required fields",
+      nextStep: "Include to and message in JSON body"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "blockedRequester",
+        status: 403,
+        userIP,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  const token = process.env.META_WHATSAPP_TOKEN;
+  const phoneId = process.env.META_WHATSAPP_PHONE_NUMBER_ID;
+
+  if (!token || !phoneId) {
+    const msg = "Missing Meta WhatsApp credentials";
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "configCheck",
+        status: 500,
+        userIP,
+        message: msg
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: msg,
+      error: msg,
+      nextStep: "Set META_WHATSAPP_TOKEN and META_WHATSAPP_PHONE_NUMBER_ID"
+    });
+  }
+
+  try {
+    const url = `https://graph.facebook.com/v17.0/${phoneId}/messages`;
+    const metaRes = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        to,
+        type: "text",
+        text: { body: message }
+      })
+    });
+
+    const metaData = await metaRes.json();
+
+    if (!metaRes.ok) {
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route,
+          action: "metaCall",
+          status: metaRes.status || 500,
+          userIP,
+          message: "Meta API error"
+        })
+      );
+      return res.status(500).json({
+        success: false,
+        status: 500,
+        summary: "Meta API error",
+        error: metaData.error?.message || "Meta API error"
+      });
+    }
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "metaCall",
+        status: 200,
+        userIP,
+        summary: "Message sent"
+      })
+    );
+
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Message sent",
+      data: metaData
+    });
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "error",
+        status: 500,
+        userIP,
+        message: error.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vercel dev",
     "start": "node api/notion-write.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "e2e:whatsapp": "node scripts/whatsappSendPreview.js"
   },
   "dependencies": {
     "@notionhq/client": "^2.2.4"

--- a/scripts/whatsappSendPreview.js
+++ b/scripts/whatsappSendPreview.js
@@ -1,0 +1,19 @@
+const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000";
+
+(async () => {
+  try {
+    const res = await fetch(`${baseUrl}/api/whatsapp/send`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        to: process.argv[2] || "1234567890",
+        message: "E2E preview message",
+        requester: "preview-script"
+      })
+    });
+    const data = await res.json();
+    console.log(data);
+  } catch (err) {
+    console.error(err);
+  }
+})();

--- a/tests/whatsappSend.test.js
+++ b/tests/whatsappSend.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/whatsapp/send.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.META_WHATSAPP_TOKEN = "token";
+  process.env.META_WHATSAPP_PHONE_NUMBER_ID = "12345";
+  vi.resetAllMocks();
+});
+
+describe("whatsapp send", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST", body: { to: "1", message: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when body missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { to: "1", message: "hi", requester: "Ruslantara" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 500 when Meta API fails", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: { message: "fail" } })
+    });
+    const req = httpMocks.createRequest({ method: "POST", body: { to: "1", message: "hi", requester: "user" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 200 on success", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "123" })
+    });
+    const req = httpMocks.createRequest({ method: "POST", body: { to: "1", message: "hi", requester: "user" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+    expect(global.fetch).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add WhatsApp send API with body validation and Meta call
- cover send endpoint with unit tests
- add E2E preview script for WhatsApp send

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c505362bc8330b4fd2c341fd75753