### PR TITLE
Add Google OAuth and calendar event creation handlers with tests

### DIFF
--- a/api/google/calendar.create_event.js
+++ b/api/google/calendar.create_event.js
@@ -1,0 +1,167 @@
+import { validateOpenAIKey } from "../../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../../helpers/checkBlockedRequester.js";
+import { loadTokens } from "../../helpers/googleTokens.js";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/calendar.create_event",
+        action: "methodCheck",
+        status: 405,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/calendar.create_event",
+        action: "keyValidation",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { summary, start, end, requester, description } = req.body || {};
+
+  if (!summary || !start || !end) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/calendar.create_event",
+        action: "bodyValidation",
+        status: 400,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Missing summary, start or end"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing summary, start or end",
+      error: "Missing summary, start or end",
+      nextStep: "Include summary, start and end"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/calendar.create_event",
+        action: "blockedRequester",
+        status: 403,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  const tokens = await loadTokens();
+  if (!tokens?.access_token) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/calendar.create_event",
+        action: "tokenLoad",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Missing tokens"
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Missing tokens",
+      error: "Missing tokens",
+      nextStep: "Authorize with Google OAuth"
+    });
+  }
+
+  try {
+    const response = await fetch(
+      "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${tokens.access_token}`,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          summary,
+          description,
+          start: { dateTime: start },
+          end: { dateTime: end }
+        })
+      }
+    );
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error?.message || "Failed to create event");
+    }
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/calendar.create_event",
+        action: "createEvent",
+        status: 200,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        success: true
+      })
+    );
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Event created",
+      data,
+      nextStep: "Event scheduled"
+    });
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/calendar.create_event",
+        action: "createEvent",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: error.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Failed to create event",
+      error: "Failed to create event",
+      nextStep: "Check logs and retry"
+    });
+  }
+}

--- a/api/google/oauth.js
+++ b/api/google/oauth.js
@@ -1,0 +1,143 @@
+import { validateOpenAIKey } from "../../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../../helpers/checkBlockedRequester.js";
+import { saveTokens } from "../../helpers/googleTokens.js";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/oauth",
+        action: "methodCheck",
+        status: 405,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/oauth",
+        action: "keyValidation",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { code, redirect_uri, requester } = req.body || {};
+
+  if (!code || !redirect_uri) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/oauth",
+        action: "bodyValidation",
+        status: 400,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Missing code or redirect_uri"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing code or redirect_uri",
+      error: "Missing code or redirect_uri",
+      nextStep: "Include code and redirect_uri"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/oauth",
+        action: "blockedRequester",
+        status: 403,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    const params = new URLSearchParams({
+      code,
+      client_id: process.env.GOOGLE_CLIENT_ID,
+      client_secret: process.env.GOOGLE_CLIENT_SECRET,
+      redirect_uri,
+      grant_type: "authorization_code"
+    });
+    const response = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: params
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error || "OAuth exchange failed");
+    }
+    await saveTokens(data);
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/oauth",
+        action: "exchange",
+        status: 200,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        success: true
+      })
+    );
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Tokens saved",
+      data: { access_token: data.access_token },
+      nextStep: "Use token for Google API requests"
+    });
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/google/oauth",
+        action: "exchange",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: error.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "OAuth exchange failed",
+      error: "OAuth exchange failed",
+      nextStep: "Verify OAuth code and credentials"
+    });
+  }
+}

--- a/helpers/googleTokens.js
+++ b/helpers/googleTokens.js
@@ -1,0 +1,15 @@
+import { promises as fs } from "fs";
+const TOKEN_PATH = "./lib/google_tokens.json";
+
+export async function saveTokens(tokens) {
+  await fs.writeFile(TOKEN_PATH, JSON.stringify(tokens, null, 2));
+}
+
+export async function loadTokens() {
+  try {
+    const data = await fs.readFile(TOKEN_PATH, "utf-8");
+    return JSON.parse(data);
+  } catch {
+    return null;
+  }
+}

--- a/tests/googleCalendarCreateEvent.test.js
+++ b/tests/googleCalendarCreateEvent.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { promises as fs } from "fs";
+import handler from "../api/google/calendar.create_event.js";
+import oauthHandler from "../api/google/oauth.js";
+
+const TOKEN_PATH = "./lib/google_tokens.json";
+
+beforeEach(async () => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.GOOGLE_CLIENT_ID = "cid";
+  process.env.GOOGLE_CLIENT_SECRET = "secret";
+  vi.resetAllMocks();
+  try {
+    await fs.unlink(TOKEN_PATH);
+  } catch {}
+});
+
+describe("google calendar create event handler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 400 when fields missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { summary: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { summary: "a", start: "s", end: "e", requester: "Deanto" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 500 when tokens missing", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { summary: "a", start: "s", end: "e", requester: "me" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("creates event successfully (E2E)", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ access_token: "a", refresh_token: "r" })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: "123" })
+      });
+
+    const oauthReq = httpMocks.createRequest({
+      method: "POST",
+      body: { code: "c", redirect_uri: "uri" }
+    });
+    const oauthRes = httpMocks.createResponse();
+    await oauthHandler(oauthReq, oauthRes);
+    expect(oauthRes.statusCode).toBe(200);
+
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: {
+        summary: "meeting",
+        start: "2024-01-01T10:00:00Z",
+        end: "2024-01-01T11:00:00Z",
+        requester: "user"
+      }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+    expect(data.data.id).toBe("123");
+  });
+});

--- a/tests/googleOauthHandler.test.js
+++ b/tests/googleOauthHandler.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { promises as fs } from "fs";
+import handler from "../api/google/oauth.js";
+
+const TOKEN_PATH = "./lib/google_tokens.json";
+
+beforeEach(async () => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.GOOGLE_CLIENT_ID = "cid";
+  process.env.GOOGLE_CLIENT_SECRET = "secret";
+  vi.resetAllMocks();
+  try {
+    await fs.unlink(TOKEN_PATH);
+  } catch {}
+});
+
+afterEach(async () => {
+  try {
+    await fs.unlink(TOKEN_PATH);
+  } catch {}
+});
+
+describe("google oauth handler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 400 when code missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { redirect_uri: "http://localhost" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { code: "c", redirect_uri: "uri", requester: "Ruslantara" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("exchanges code and saves tokens", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: "a", refresh_token: "r" })
+    });
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { code: "c", redirect_uri: "uri", requester: "me" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const content = await fs.readFile(TOKEN_PATH, "utf-8");
+    expect(JSON.parse(content).access_token).toBe("a");
+  });
+});


### PR DESCRIPTION
## Summary
- implement Google OAuth exchange endpoint with token persistence
- add calendar event creation endpoint using saved tokens
- provide unit tests and E2E flow for OAuth and calendar handlers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c50514bd883308da94a6569422d16