### PR TITLE
feat: add canva job queue endpoints

### DIFF
--- a/api/canva/generate.js
+++ b/api/canva/generate.js
@@ -1,0 +1,3 @@
+import { canvaGenerateHandler } from "../../handlers/canvaGenerateHandler.js";
+
+export default canvaGenerateHandler;

--- a/api/canva/status.js
+++ b/api/canva/status.js
@@ -1,0 +1,3 @@
+import { canvaStatusHandler } from "../../handlers/canvaStatusHandler.js";
+
+export default canvaStatusHandler;

--- a/handlers/canvaGenerateHandler.js
+++ b/handlers/canvaGenerateHandler.js
@@ -1,0 +1,114 @@
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+import { enqueueCanvaJob } from "../helpers/jobQueue.js";
+
+export async function canvaGenerateHandler(req, res) {
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "methodCheck",
+      status: 405,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "keyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { prompt, requester } = req.body || {};
+
+  if (!prompt) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "promptValidation",
+      status: 400,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Missing prompt in request body"
+    }));
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing prompt in request body",
+      error: "Missing prompt in request body",
+      nextStep: "Include prompt in JSON body"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "blockedRequester",
+      status: 403,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Requester is blocked"
+    }));
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    const jobId = enqueueCanvaJob({ prompt });
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "enqueue",
+      status: 202,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      summary: "Job enqueued"
+    }));
+    return res.status(202).json({
+      success: true,
+      status: 202,
+      summary: "Job enqueued",
+      data: { jobId }
+    });
+  } catch (error) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "error",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Internal Server Error"
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}

--- a/handlers/canvaStatusHandler.js
+++ b/handlers/canvaStatusHandler.js
@@ -1,0 +1,96 @@
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { getCanvaJob } from "../helpers/jobQueue.js";
+
+export async function canvaStatusHandler(req, res) {
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/status",
+      action: "methodCheck",
+      status: 405,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/status",
+      action: "keyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { jobId } = req.body || {};
+
+  if (!jobId) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/status",
+      action: "jobIdValidation",
+      status: 400,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Missing jobId in request body"
+    }));
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing jobId in request body",
+      error: "Missing jobId in request body",
+      nextStep: "Include jobId in JSON body"
+    });
+  }
+
+  const job = getCanvaJob(jobId);
+
+  if (!job) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/status",
+      action: "jobNotFound",
+      status: 404,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Job not found"
+    }));
+    return res.status(404).json({
+      success: false,
+      status: 404,
+      summary: "Job not found",
+      error: "Job not found"
+    });
+  }
+
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    route: "/api/canva/status",
+    action: "statusCheck",
+    status: 200,
+    userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+    summary: "Job status retrieved"
+  }));
+  return res.status(200).json({
+    success: true,
+    status: 200,
+    summary: "Job status retrieved",
+    data: job
+  });
+}

--- a/helpers/jobQueue.js
+++ b/helpers/jobQueue.js
@@ -1,0 +1,25 @@
+import { randomUUID } from "crypto";
+
+const jobs = new Map();
+
+async function processJob(id, payload) {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  jobs.set(id, { status: "completed", result: payload });
+}
+
+export function enqueueCanvaJob(payload) {
+  const id = randomUUID();
+  jobs.set(id, { status: "pending", result: null });
+  processJob(id, payload).catch((err) => {
+    jobs.set(id, { status: "error", result: err.message });
+  });
+  return id;
+}
+
+export function getCanvaJob(id) {
+  return jobs.get(id);
+}
+
+export function resetCanvaQueue() {
+  jobs.clear();
+}

--- a/tests/canvaHandlers.test.js
+++ b/tests/canvaHandlers.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { canvaGenerateHandler } from "../handlers/canvaGenerateHandler.js";
+import { canvaStatusHandler } from "../handlers/canvaStatusHandler.js";
+import { resetCanvaQueue } from "../helpers/jobQueue.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  resetCanvaQueue();
+  vi.useRealTimers();
+});
+
+describe("canva job queue", () => {
+  it("enqueues job and completes", async () => {
+    vi.useFakeTimers();
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "design" } });
+    const res = httpMocks.createResponse();
+    await canvaGenerateHandler(req, res);
+    expect(res.statusCode).toBe(202);
+    const { data: { jobId } } = JSON.parse(res._getData());
+
+    let statusReq = httpMocks.createRequest({ method: "POST", body: { jobId } });
+    let statusRes = httpMocks.createResponse();
+    await canvaStatusHandler(statusReq, statusRes);
+    let body = JSON.parse(statusRes._getData());
+    expect(body.data.status).toBe("pending");
+
+    await vi.advanceTimersByTimeAsync(60);
+
+    statusRes = httpMocks.createResponse();
+    await canvaStatusHandler(statusReq, statusRes);
+    body = JSON.parse(statusRes._getData());
+    expect(body.data.status).toBe("completed");
+    vi.useRealTimers();
+  });
+
+  it("returns 400 when jobId missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await canvaStatusHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add in-memory job queue helper
- enqueue Canva generation requests through `/api/canva/generate`
- poll job status via `/api/canva/status`
- test enqueue and polling flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c504faeb483308edd8dba4d6d6c60