### PR TITLE
Add Visa Oracle API handler and tests

### DIFF
--- a/api/visaOracle.js
+++ b/api/visaOracle.js
@@ -1,3 +1,4 @@
 import { createAgentHandler } from "../handlers/createAgentHandler.js";
 
+// Use the shared agent handler for the Visa Oracle agent
 export default createAgentHandler("Visa Oracle");

--- a/tests/visaOracle.test.js
+++ b/tests/visaOracle.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/visaOracle.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  vi.resetAllMocks();
+});
+
+describe("visaOracle handler", () => {
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { prompt: "hi", requester: "Ruslantara" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 200 on success", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ result: "ok" })
+    });
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { prompt: "hi", requester: "user" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- leverage shared agent handler for Visa Oracle endpoint
- test Visa Oracle endpoint for successful response and blocked requester

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5049130483308fff8975670a664f