### PR TITLE
feat: add setup master handler

### DIFF
--- a/api/setupMaster.js
+++ b/api/setupMaster.js
@@ -1,3 +1,148 @@
-import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+import { getAgentPrompt } from "../constants/prompts.js";
 
-export default createAgentHandler("Setup Master");
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/setupMaster",
+        action: "methodCheck",
+        status: 405,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Method Not Allowed",
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request",
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/setupMaster",
+        action: "keyValidation",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: err.message,
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment",
+    });
+  }
+
+  const { prompt, requester } = req.body || {};
+
+  if (!prompt) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/setupMaster",
+        action: "promptValidation",
+        status: 400,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Missing prompt in request body",
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing prompt in request body",
+      error: "Missing prompt in request body",
+      nextStep: "Include prompt in JSON body",
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/setupMaster",
+        action: "blockedRequester",
+        status: 403,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Requester is blocked",
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied",
+    });
+  }
+
+  const agentPrompt = getAgentPrompt("Setup Master");
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
+        "Notion-Version": "2022-06-28",
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: agentPrompt },
+          { role: "user", content: prompt },
+        ],
+      }),
+    });
+
+    const data = await response.json();
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/setupMaster",
+        action: "success",
+        status: 200,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        summary: "Request completed successfully",
+      })
+    );
+
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Request completed successfully",
+      data,
+    });
+  } catch (error) {
+    console.error("Error fetching data from OpenAI:", error);
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/setupMaster",
+        action: "error",
+        status: 500,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Internal Server Error",
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry",
+    });
+  }
+}
+

--- a/tests/setupMaster.test.js
+++ b/tests/setupMaster.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/setupMaster.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+});
+
+describe("setupMaster handler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when prompt missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { prompt: "hi", requester: "Ruslantara" },
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 200 on success", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ result: "ok" }),
+    });
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).success).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- implement Setup Master endpoint with request validation and structured logging
- add unit tests for the new handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5047ac048330a17f57c18edfe3a3