### PR TITLE
log agent responses to Notion

### DIFF
--- a/api/antonelloDaily.js
+++ b/api/antonelloDaily.js
@@ -1,3 +1,6 @@
 import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { writeAgentResult } from "../helpers/notionLogger.js";
 
-export default createAgentHandler("Antonello Daily");
+export default createAgentHandler("Antonello Daily", async (prompt, data) => {
+  await writeAgentResult("antonelloDaily", prompt, data);
+});

--- a/api/baliZeroHub.js
+++ b/api/baliZeroHub.js
@@ -1,3 +1,6 @@
 import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { writeAgentResult } from "../helpers/notionLogger.js";
 
-export default createAgentHandler("Bali Zero Hub");
+export default createAgentHandler("Bali Zero Hub", async (prompt, data) => {
+  await writeAgentResult("baliZeroHub", prompt, data);
+});

--- a/api/morgana.js
+++ b/api/morgana.js
@@ -1,3 +1,6 @@
 import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { writeAgentResult } from "../helpers/notionLogger.js";
 
-export default createAgentHandler("Morgana");
+export default createAgentHandler("Morgana", async (prompt, data) => {
+  await writeAgentResult("morgana", prompt, data);
+});

--- a/api/setupMaster.js
+++ b/api/setupMaster.js
@@ -1,3 +1,6 @@
 import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { writeAgentResult } from "../helpers/notionLogger.js";
 
-export default createAgentHandler("Setup Master");
+export default createAgentHandler("Setup Master", async (prompt, data) => {
+  await writeAgentResult("setupMaster", prompt, data);
+});

--- a/api/taxGenius.js
+++ b/api/taxGenius.js
@@ -1,3 +1,6 @@
 import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { writeAgentResult } from "../helpers/notionLogger.js";
 
-export default createAgentHandler("Tax Genius");
+export default createAgentHandler("Tax Genius", async (prompt, data) => {
+  await writeAgentResult("taxGenius", prompt, data);
+});

--- a/api/theLegalArchitect.js
+++ b/api/theLegalArchitect.js
@@ -1,3 +1,6 @@
 import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { writeAgentResult } from "../helpers/notionLogger.js";
 
-export default createAgentHandler("The Legal Architect");
+export default createAgentHandler("The Legal Architect", async (prompt, data) => {
+  await writeAgentResult("theLegalArchitect", prompt, data);
+});

--- a/api/visaOracle.js
+++ b/api/visaOracle.js
@@ -1,3 +1,6 @@
 import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { writeAgentResult } from "../helpers/notionLogger.js";
 
-export default createAgentHandler("Visa Oracle");
+export default createAgentHandler("Visa Oracle", async (prompt, data) => {
+  await writeAgentResult("visaOracle", prompt, data);
+});

--- a/handlers/createAgentHandler.js
+++ b/handlers/createAgentHandler.js
@@ -2,7 +2,7 @@ import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
 import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
 import { getAgentPrompt } from "../constants/prompts.js";
 
-export function createAgentHandler(agentName) {
+export function createAgentHandler(agentName, onResult) {
   return async function handler(req, res) {
     if (req.method !== "POST") {
       console.log(JSON.stringify({
@@ -99,6 +99,23 @@ export function createAgentHandler(agentName) {
       });
 
       const data = await response.json();
+
+      try {
+        if (onResult) {
+          await onResult(prompt, data);
+        }
+      } catch (err) {
+        console.log(
+          JSON.stringify({
+            timestamp: new Date().toISOString(),
+            route: `/api/${agentName}`,
+            action: "logError",
+            status: 500,
+            userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+            message: err.message
+          })
+        );
+      }
 
       console.log(JSON.stringify({
         timestamp: new Date().toISOString(),

--- a/helpers/notionLogger.js
+++ b/helpers/notionLogger.js
@@ -1,0 +1,48 @@
+import { Client } from "@notionhq/client";
+
+export async function writeAgentResult(agentName, prompt, result) {
+  const client = new Client({ auth: process.env.NOTION_TOKEN });
+  const databaseId = process.env.NOTION_LOG_DB_ID;
+
+  try {
+    await client.pages.create({
+      parent: { database_id: databaseId },
+      properties: {
+        Agent: { title: [{ text: { content: agentName } }] },
+        Prompt: { rich_text: [{ text: { content: String(prompt) } }] },
+        Result: {
+          rich_text: [
+            {
+              text: {
+                content:
+                  typeof result === "string" ? result : JSON.stringify(result)
+              }
+            }
+          ]
+        }
+      }
+    });
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "helpers/notionLogger",
+        action: "write",
+        status: 200,
+        agentName
+      })
+    );
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "helpers/notionLogger",
+        action: "error",
+        status: 500,
+        agentName,
+        message: error.message
+      })
+    );
+    throw error;
+  }
+}

--- a/tests/notionLogger.test.js
+++ b/tests/notionLogger.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+
+vi.mock("../helpers/notionLogger.js", () => ({
+  writeAgentResult: vi.fn().mockResolvedValue()
+}));
+
+import handler from "../api/morgana.js";
+import { writeAgentResult } from "../helpers/notionLogger.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  vi.clearAllMocks();
+  writeAgentResult.mockResolvedValue();
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ result: "ok" })
+  });
+});
+
+describe("morgana handler notion log", () => {
+  it("calls writeAgentResult with correct payload", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(writeAgentResult).toHaveBeenCalledWith("morgana", "hi", { result: "ok" });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("continues when writeAgentResult fails", async () => {
+    writeAgentResult.mockRejectedValueOnce(new Error("fail"));
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hello" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- log agent outputs to Notion via new `writeAgentResult` helper
- extend `createAgentHandler` to support result callbacks
- record agent responses in Notion for all handlers and cover with tests

## Testing
- `npm test`
- `npm test tests/notionLogger.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689c688b4cdc8330ab942e9ba71b6f0a