### PR TITLE
Add GET-only Notion callback with key validation and tests

### DIFF
--- a/api/notion/callback.js
+++ b/api/notion/callback.js
@@ -1,23 +1,99 @@
-import axios from 'axios';
+import axios from "axios";
+import { validateOpenAIKey } from "../../helpers/validateOpenAIKey.js";
 
 export default async function handler(req, res) {
-  const { code } = req.query;
+  const route = "/api/notion/callback";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
 
-  if (!code || typeof code !== 'string') {
-    return res.status(400).json({ error: 'Missing or invalid `code` parameter' });
+  if (req.method !== "GET") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "methodCheck",
+        status: 405,
+        userIP,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a GET request"
+    });
   }
 
-  console.log("🔐 ENV VARIABLES CHECK:");
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "keyValidation",
+        status: 500,
+        userIP,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { code } = req.query;
+
+  if (!code || typeof code !== "string") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "codeValidation",
+        status: 400,
+        userIP,
+        message: "Missing or invalid `code` parameter"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing or invalid `code` parameter",
+      error: "Missing or invalid `code` parameter",
+      nextStep: "Include valid code in query string"
+    });
+  }
+
   const notionToken = process.env.NOTION_TOKEN;
   const notionDatabaseId = process.env.NOTION_DATABASE_ID;
 
   if (!notionToken || !notionDatabaseId) {
-    console.error("❌ Missing NOTION_TOKEN or NOTION_DATABASE_ID");
-    return res.status(500).json({ error: "Missing environment variables" });
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "envValidation",
+        status: 500,
+        userIP,
+        message: "Missing Notion credentials"
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Missing Notion credentials",
+      error: "Missing environment variables",
+      nextStep: "Set NOTION_TOKEN and NOTION_DATABASE_ID"
+    });
   }
 
   try {
-    // 🔄 Optional: trasformazione del codice in contenuto Notion
+    // Optional: transform the code into Notion content
     const newEntry = {
       parent: { database_id: notionDatabaseId },
       properties: {
@@ -28,22 +104,51 @@ export default async function handler(req, res) {
     };
 
     const notionRes = await axios.post(
-      'https://api.notion.com/v1/pages',
+      "https://api.notion.com/v1/pages",
       newEntry,
       {
         headers: {
-          'Authorization': `Bearer ${notionToken}`,
-          'Content-Type': 'application/json',
-          'Notion-Version': '2022-06-28'
+          Authorization: `Bearer ${notionToken}`,
+          "Content-Type": "application/json",
+          "Notion-Version": "2022-06-28"
         }
       }
     );
 
-    console.log("✅ Entry saved to Notion:", notionRes.data.id);
-    return res.status(200).json({ success: true, notionPageId: notionRes.data.id });
-
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "success",
+        status: 200,
+        userIP,
+        summary: "Entry saved to Notion"
+      })
+    );
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Entry saved to Notion",
+      data: { notionPageId: notionRes.data.id }
+    });
   } catch (error) {
-    console.error("❌ Error saving to Notion:", error.response?.data || error.message);
-    return res.status(500).json({ error: "Failed to save to Notion" });
+    console.error("Error saving to Notion:", error.response?.data || error.message);
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "error",
+        status: 500,
+        userIP,
+        message: "Failed to save to Notion"
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Failed to save to Notion",
+      error: "Failed to save to Notion",
+      nextStep: "Check server logs and retry"
+    });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "zantara-api",
       "version": "1.0.0",
       "dependencies": {
-        "@notionhq/client": "^2.2.4"
+        "@notionhq/client": "^2.2.4",
+        "axios": "^1.6.7"
       },
       "devDependencies": {
         "node-mocks-http": "^1.17.2",
@@ -945,6 +946,17 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1206,6 +1218,26 @@
       },
       "peerDependenciesMeta": {
         "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
           "optional": true
         }
       }
@@ -1610,6 +1642,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@notionhq/client": "^2.2.4"
+    "@notionhq/client": "^2.2.4",
+    "axios": "^1.6.7"
   },
   "devDependencies": {
     "vitest": "^3.2.4",

--- a/tests/notionCallback.test.js
+++ b/tests/notionCallback.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/notion/callback.js";
+import axios from "axios";
+
+vi.mock("axios");
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.NOTION_TOKEN = "token";
+  process.env.NOTION_DATABASE_ID = "db";
+  vi.resetAllMocks();
+});
+
+describe("notion callback handler", () => {
+  it("returns 405 for non-GET", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "GET", query: { code: "abc" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when code missing", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 200 on success", async () => {
+    axios.post.mockResolvedValue({ data: { id: "123" } });
+    const req = httpMocks.createRequest({ method: "GET", query: { code: "abc" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+    expect(data.data.notionPageId).toBe("123");
+    expect(axios.post).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- enforce GET-only access for Notion callback with OpenAI key and Notion env validation
- replace Italian comment, add structured JSON logging and uniform { success, status, summary } responses
- add axios dependency and unit tests for new handler behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c5690a0cc8330a6914df16bad2af2