### PR TITLE
Refactor WhatsApp webhook handler with unified validation

### DIFF
--- a/api/whatsapp/webhook.js
+++ b/api/whatsapp/webhook.js
@@ -1,22 +1,3 @@
-export default function handler(req, res) {
-  const VERIFY_TOKEN = process.env.ZANTARA_WHATSAPP_TOKEN || "ZANTARA_WHATSAPP_TOKEN";
+import handler from "../../pages/api/webhooks/meta/whatsapp.js";
 
-  if (req.method === "GET") {
-    const mode = req.query["hub.mode"];
-    const token = req.query["hub.verify_token"];
-    const challenge = req.query["hub.challenge"];
-    if (mode === "subscribe" && token === VERIFY_TOKEN && challenge) {
-      res.setHeader("Content-Type", "text/plain");
-      return res.status(200).send(challenge);
-    }
-    return res.sendStatus(403);
-  }
-
-  if (req.method === "POST") {
-    console.log("WhatsApp incoming:", JSON.stringify(req.body || {}, null, 2));
-    return res.sendStatus(200);
-  }
-
-  res.setHeader("Allow", ["GET", "POST"]);
-  res.status(405).end(`Method ${req.method} Not Allowed`);
-}
+export default handler;

--- a/pages/api/webhooks/meta/whatsapp.js
+++ b/pages/api/webhooks/meta/whatsapp.js
@@ -16,7 +16,22 @@ export default async function handler(req, res) {
       );
       return res.status(200).send(challenge);
     }
-    return res.status(400).send("Missing challenge");
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/pages/api/webhooks/meta/whatsapp",
+        action: "challenge",
+        status: 400,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Missing challenge"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing challenge",
+      error: "Missing challenge"
+    });
   }
 
   if (req.method !== "POST") {
@@ -35,7 +50,7 @@ export default async function handler(req, res) {
       status: 405,
       summary: "Method Not Allowed",
       error: "Method Not Allowed",
-      nextStep: "Use GET or POST"
+      nextStep: "Use POST"
     });
   }
 
@@ -61,7 +76,46 @@ export default async function handler(req, res) {
     });
   }
 
+  if (req.headers["content-type"] !== "application/json") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/pages/api/webhooks/meta/whatsapp",
+        action: "contentType",
+        status: 400,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Invalid Content-Type"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Invalid content type",
+      error: "Content-Type must be application/json",
+      nextStep: "Set Content-Type to application/json"
+    });
+  }
+
   const { requester } = req.body || {};
+  if (!requester) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/pages/api/webhooks/meta/whatsapp",
+        action: "payloadValidation",
+        status: 400,
+        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+        message: "Missing requester"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Invalid payload",
+      error: "Missing requester",
+      nextStep: "Include requester in body"
+    });
+  }
 
   if (isBlockedRequester(requester)) {
     console.log(

--- a/tests/whatsappWebhook.test.js
+++ b/tests/whatsappWebhook.test.js
@@ -27,7 +27,11 @@ describe("whatsapp webhook", () => {
 
   it("returns 500 when API key missing", async () => {
     delete process.env.OPENAI_API_KEY;
-    const req = httpMocks.createRequest({ method: "POST" });
+    const req = httpMocks.createRequest({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: { requester: "Alice" }
+    });
     const res = httpMocks.createResponse();
     await handler(req, res);
     expect(res.statusCode).toBe(500);
@@ -36,6 +40,7 @@ describe("whatsapp webhook", () => {
   it("blocks specified requester", async () => {
     const req = httpMocks.createRequest({
       method: "POST",
+      headers: { "content-type": "application/json" },
       body: { requester: "Ruslantara" }
     });
     const res = httpMocks.createResponse();
@@ -43,8 +48,34 @@ describe("whatsapp webhook", () => {
     expect(res.statusCode).toBe(403);
   });
 
+  it("returns 400 for invalid content type", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: { requester: "Alice" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 400 when requester missing", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: {}
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
   it("returns 200 on valid POST", async () => {
-    const req = httpMocks.createRequest({ method: "POST", body: {} });
+    const req = httpMocks.createRequest({
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: { requester: "Alice" }
+    });
     const res = httpMocks.createResponse();
     await handler(req, res);
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
## Summary
- remove duplicate WhatsApp webhook implementation by re-exporting unified handler
- enforce POST-only, OpenAI key, JSON content-type, requester checks, and blocked-requester rules with structured JSON logs
- expand webhook tests for content-type and requester validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c568ce7cc8330bdedfea6cd43c2cd