### PR TITLE
Fix header construction in Zantara orchestrator

### DIFF
--- a/api/zantara.js
+++ b/api/zantara.js
@@ -106,8 +106,10 @@ export default async function handler(req, res) {
       try {
         const response = await fetch(`${baseUrl}/api/${agent}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          "Notion-Version": "2022-06-28"
+          headers: {
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28"
+          },
           body: JSON.stringify({ prompt, requester })
         });
         results[agent] = await response.json();


### PR DESCRIPTION
## Summary
- fix incorrect placement of `Notion-Version` header when invoking agents

## Testing
- `npx vitest run tests/zantara.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6892689349048330af4a24010a1ccb75