### PR TITLE
feat: add trigger endpoint

### DIFF
--- a/api/trigger.js
+++ b/api/trigger.js
@@ -1,0 +1,2 @@
+import { triggerHandler } from "../handlers/triggerHandler.js";
+export default triggerHandler;

--- a/handlers/triggerHandler.js
+++ b/handlers/triggerHandler.js
@@ -1,0 +1,147 @@
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+
+export async function triggerHandler(req, res) {
+  const route = "/api/trigger";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
+
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "methodCheck",
+        status: 405,
+        userIP,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  const authHeader = req.headers.authorization;
+  if (authHeader !== `Bearer ${process.env.ZANTARA_SECRET_KEY}`) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "authCheck",
+        status: 403,
+        userIP,
+        message: "Invalid or missing Authorization header"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Invalid or missing Authorization header",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "keyValidation",
+        status: 500,
+        userIP,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { prompt, requester } = req.body || {};
+  if (!prompt) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "promptValidation",
+        status: 400,
+        userIP,
+        message: "Missing prompt in request body"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing prompt in request body",
+      error: "Missing prompt in request body",
+      nextStep: "Include prompt in JSON body"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "blockedRequester",
+        status: 403,
+        userIP,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "trigger",
+        status: 200,
+        userIP,
+        summary: "Trigger accepted"
+      })
+    );
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Trigger accepted",
+      data: { message: "Trigger processed" }
+    });
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "error",
+        status: 500,
+        userIP,
+        message: "Internal Server Error"
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}
+

--- a/tests/triggerHandler.test.js
+++ b/tests/triggerHandler.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import httpMocks from "node-mocks-http";
+import { triggerHandler } from "../handlers/triggerHandler.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.ZANTARA_SECRET_KEY = "secret";
+});
+
+describe("triggerHandler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await triggerHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 403 for missing auth", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await triggerHandler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST", headers: { Authorization: "Bearer secret" } });
+    const res = httpMocks.createResponse();
+    await triggerHandler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when prompt missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST", headers: { Authorization: "Bearer secret" } });
+    const res = httpMocks.createResponse();
+    await triggerHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      headers: { Authorization: "Bearer secret" },
+      body: { prompt: "hi", requester: "Ruslantara" }
+    });
+    const res = httpMocks.createResponse();
+    await triggerHandler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 200 on success", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      headers: { Authorization: "Bearer secret" },
+      body: { prompt: "hello" }
+    });
+    const res = httpMocks.createResponse();
+    await triggerHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).success).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `/api/trigger` endpoint with Authorization validation and structured logging
- include Vitest coverage for trigger handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68905164daa88330baa22794a9d372d8