### PR TITLE
feat: add scraper orchestrator endpoint

### DIFF
--- a/api/scraper/run.js
+++ b/api/scraper/run.js
@@ -1,0 +1,117 @@
+import { validateOpenAIKey } from "../../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../../helpers/checkBlockedRequester.js";
+import { invokeApify, fetchBrowserlessContent } from "../../helpers/scrape.js";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/scraper/run",
+      action: "methodCheck",
+      status: 405,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/scraper/run",
+      action: "keyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { url, actorId, input, apifyToken, browserlessToken, requester } = req.body || {};
+
+  if (!url || !actorId) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/scraper/run",
+      action: "payloadValidation",
+      status: 400,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Missing url or actorId"
+    }));
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing url or actorId",
+      error: "Missing url or actorId",
+      nextStep: "Include url and actorId in JSON body"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/scraper/run",
+      action: "blockedRequester",
+      status: 403,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Requester is blocked"
+    }));
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    const apifyResult = await invokeApify(actorId, input, apifyToken);
+    const browserlessResult = await fetchBrowserlessContent(url, browserlessToken);
+
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/scraper/run",
+      action: "success",
+      status: 200,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      summary: "Scraping completed"
+    }));
+
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Scraping completed",
+      data: { apifyResult, browserlessResult }
+    });
+  } catch (error) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/scraper/run",
+      action: "error",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: error.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Scraping failed",
+      error: error.message,
+      nextStep: "Check service tokens and retry"
+    });
+  }
+}

--- a/helpers/scrape.js
+++ b/helpers/scrape.js
@@ -1,0 +1,26 @@
+export async function invokeApify(actorId, input = {}, token) {
+  const response = await fetch(`https://api.apify.com/v2/actor-tasks/${actorId}/runs`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {})
+    },
+    body: JSON.stringify(input)
+  });
+
+  if (!response.ok) {
+    throw new Error(`Apify request failed with status ${response.status}`);
+  }
+
+  return await response.json();
+}
+
+export async function fetchBrowserlessContent(url, token) {
+  const response = await fetch(`https://chrome.browserless.io/content?token=${token}&url=${encodeURIComponent(url)}`);
+
+  if (!response.ok) {
+    throw new Error(`Browserless request failed with status ${response.status}`);
+  }
+
+  return await response.text();
+}

--- a/tests/scraperRun.test.js
+++ b/tests/scraperRun.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+
+vi.mock("../helpers/scrape.js", () => ({
+  invokeApify: vi.fn(),
+  fetchBrowserlessContent: vi.fn()
+}));
+
+import handler from "../api/scraper/run.js";
+import { invokeApify, fetchBrowserlessContent } from "../helpers/scrape.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  vi.clearAllMocks();
+});
+
+describe("scraper run", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when url missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { actorId: "1" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 200 on success", async () => {
+    invokeApify.mockResolvedValue({ id: "run1" });
+    fetchBrowserlessContent.mockResolvedValue("<html></html>");
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { url: "https://example.com", actorId: "123" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+  });
+
+  it("returns 500 on failure", async () => {
+    invokeApify.mockRejectedValue(new Error("Apify fail"));
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { url: "https://example.com", actorId: "123" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/scraper/run` endpoint orchestrating Apify and Browserless
- encapsulate service calls with `helpers/scrape.js`
- cover success and failure scenarios with Vitest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c504b5688833094ffa076d416a282