### PR TITLE
feat: add Tax Genius API handler with tests

### DIFF
--- a/api/taxGenius.js
+++ b/api/taxGenius.js
@@ -1,3 +1,137 @@
-import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+import { getAgentPrompt } from "../constants/prompts.js";
 
-export default createAgentHandler("Tax Genius");
+const agentName = "Tax Genius";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/taxGenius",
+      action: "methodCheck",
+      status: 405,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/taxGenius",
+      action: "keyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { prompt, requester } = req.body || {};
+
+  if (!prompt) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/taxGenius",
+      action: "promptValidation",
+      status: 400,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Missing prompt in request body"
+    }));
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing prompt in request body",
+      error: "Missing prompt in request body",
+      nextStep: "Include prompt in JSON body"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/taxGenius",
+      action: "blockedRequester",
+      status: 403,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Requester is blocked"
+    }));
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  const agentPrompt = getAgentPrompt(agentName);
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
+        "Notion-Version": "2022-06-28"
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: agentPrompt },
+          { role: "user", content: prompt }
+        ]
+      })
+    });
+
+    const data = await response.json();
+
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/taxGenius",
+      action: "success",
+      status: 200,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      summary: "Request completed successfully"
+    }));
+
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Request completed successfully",
+      data
+    });
+  } catch (error) {
+    console.error("Error fetching data from OpenAI:", error);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/taxGenius",
+      action: "error",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Internal Server Error"
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}

--- a/tests/taxGenius.test.js
+++ b/tests/taxGenius.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/taxGenius.js";
+import { getAgentPrompt } from "../constants/prompts.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  vi.restoreAllMocks();
+});
+
+describe("taxGenius API", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when prompt missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi", requester: "Ruslantara" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("calls OpenAI and returns 200 on success", async () => {
+    const mockData = { result: "ok" };
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => mockData
+    });
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res._getData());
+    expect(body.success).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith("https://api.openai.com/v1/chat/completions", expect.any(Object));
+    const fetchOptions = global.fetch.mock.calls[0][1];
+    const payload = JSON.parse(fetchOptions.body);
+    expect(payload.messages[0].content).toBe(getAgentPrompt("Tax Genius"));
+  });
+});


### PR DESCRIPTION
## Summary
- implement Tax Genius API handler with method, key, prompt, and requester validation
- call OpenAI chat completions to fulfill requests
- add Vitest coverage for Tax Genius API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c5045ae908330a92681c0f90340ad