### PR TITLE
Add security middleware with rate limiting and idempotency

### DIFF
--- a/helpers/security.js
+++ b/helpers/security.js
@@ -1,0 +1,163 @@
+// Security middleware providing payload validation, rate limiting and idempotency handling.
+// Supports in-memory storage by default and allows plugging in Redis via createRedisStore.
+
+const rateLimitBuckets = new Map();
+
+export function createMemoryStore() {
+  const memoryStore = new Map();
+  return {
+    async get(key) {
+      return memoryStore.get(key) || null;
+    },
+    async set(key, value, ttl) {
+      memoryStore.set(key, value);
+      if (ttl) {
+        setTimeout(() => memoryStore.delete(key), ttl).unref();
+      }
+    }
+  };
+}
+
+export async function createRedisStore(url) {
+  const { createClient } = await import("redis");
+  const client = createClient({ url });
+  await client.connect();
+  return {
+    async get(key) {
+      const data = await client.get(key);
+      return data ? JSON.parse(data) : null;
+    },
+    async set(key, value, ttl) {
+      await client.set(key, JSON.stringify(value), { PX: ttl });
+    }
+  };
+}
+
+function checkRateLimit(identifier, tokens = 60, interval = 60000) {
+  const now = Date.now();
+  const bucket = rateLimitBuckets.get(identifier) || { tokens, last: now };
+
+  if (now - bucket.last >= interval) {
+    bucket.tokens = tokens;
+    bucket.last = now;
+  }
+
+  if (bucket.tokens <= 0) {
+    rateLimitBuckets.set(identifier, bucket);
+    return true;
+  }
+
+  bucket.tokens -= 1;
+  rateLimitBuckets.set(identifier, bucket);
+  return false;
+}
+
+export function withSecurity(handler, options = {}) {
+  const {
+    rateLimit = { tokens: 60, interval: 60000 },
+    idempotencyTTL = 3600000,
+    store = createMemoryStore()
+  } = options;
+
+  return async function secured(req, res) {
+    const route = req.url || req.originalUrl || "unknown";
+    const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress || "unknown";
+
+    if (req.method === "POST") {
+      if (!req.body || typeof req.body !== "object") {
+        console.log(
+          JSON.stringify({
+            timestamp: new Date().toISOString(),
+            route,
+            action: "payloadValidation",
+            status: 400,
+            userIP,
+            message: "Invalid JSON payload"
+          })
+        );
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          summary: "Invalid JSON payload",
+          error: "Invalid JSON payload",
+          nextStep: "Send a valid JSON body"
+        });
+      }
+    }
+
+    const rateKey = `${userIP}:${rateLimit.tokens}:${rateLimit.interval}`;
+    if (rateLimit && checkRateLimit(rateKey, rateLimit.tokens, rateLimit.interval)) {
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route,
+          action: "rateLimit",
+          status: 429,
+          userIP,
+          message: "Too Many Requests"
+        })
+      );
+      return res.status(429).json({
+        success: false,
+        status: 429,
+        summary: "Too Many Requests",
+        error: "Too Many Requests",
+        nextStep: "Please retry later"
+      });
+    }
+
+    const idempotencyKey = req.headers["idempotency-key"];
+    if (idempotencyKey) {
+      const cached = await store.get(idempotencyKey);
+      if (cached) {
+        console.log(
+          JSON.stringify({
+            timestamp: new Date().toISOString(),
+            route,
+            action: "idempotentReplay",
+            status: cached.status,
+            userIP,
+            message: "Replayed idempotent request"
+          })
+        );
+        return res.status(cached.status).json(cached.body);
+      }
+    }
+
+    let responseBody;
+    const originalJson = res.json.bind(res);
+    res.json = (body) => {
+      responseBody = body;
+      return originalJson(body);
+    };
+
+    try {
+      await handler(req, res);
+    } catch (err) {
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route,
+          action: "handlerError",
+          status: 500,
+          userIP,
+          message: err.message
+        })
+      );
+      return res.status(500).json({
+        success: false,
+        status: 500,
+        summary: "Internal Server Error",
+        error: "Internal Server Error",
+        nextStep: "Check server logs and retry"
+      });
+    }
+
+    if (idempotencyKey && responseBody) {
+      await store.set(idempotencyKey, { status: res.statusCode, body: responseBody }, idempotencyTTL);
+    }
+  };
+}
+
+export default { withSecurity, createMemoryStore, createRedisStore };
+

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import httpMocks from "node-mocks-http";
+import { withSecurity } from "../helpers/security.js";
+
+function createReqRes(headers = {}, body = {}) {
+  const req = httpMocks.createRequest({ method: "POST", url: "/", headers, body });
+  const res = httpMocks.createResponse();
+  return { req, res };
+}
+
+describe("security middleware", () => {
+  it("throttles requests exceeding token bucket", async () => {
+    let count = 0;
+    const handler = async (req, res) => {
+      count += 1;
+      res.status(200).json({ ok: true });
+    };
+    const secured = withSecurity(handler, { rateLimit: { tokens: 2, interval: 1000 } });
+
+    const { req: req1, res: res1 } = createReqRes({}, { a: 1 });
+    await secured(req1, res1);
+    expect(res1.statusCode).toBe(200);
+
+    const { req: req2, res: res2 } = createReqRes({}, { a: 1 });
+    await secured(req2, res2);
+    expect(res2.statusCode).toBe(200);
+
+    const { req: req3, res: res3 } = createReqRes({}, { a: 1 });
+    await secured(req3, res3);
+    expect(res3.statusCode).toBe(429);
+    expect(count).toBe(2);
+  });
+
+  it("returns stored response for duplicate idempotency key", async () => {
+    let count = 0;
+    const handler = async (req, res) => {
+      count += 1;
+      res.status(200).json({ value: count });
+    };
+    const secured = withSecurity(handler);
+
+    const headers = { "idempotency-key": "abc" };
+    const { req: req1, res: res1 } = createReqRes(headers, {});
+    await secured(req1, res1);
+    expect(res1.statusCode).toBe(200);
+    const first = res1._getJSONData();
+    expect(first.value).toBe(1);
+
+    const { req: req2, res: res2 } = createReqRes(headers, {});
+    await secured(req2, res2);
+    expect(res2.statusCode).toBe(200);
+    const second = res2._getJSONData();
+    expect(second.value).toBe(1);
+    expect(count).toBe(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add reusable security middleware for payload validation, rate limiting and idempotency keys
- apply middleware to Zantara orchestrator and new WhatsApp send endpoint
- test rate limiting and idempotent replay behaviors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c4ccedb6083308494a88604014dff