### PR TITLE
Add Tax Genius prompt and tests

### DIFF
--- a/constants/prompts.js
+++ b/constants/prompts.js
@@ -1,3 +1,11 @@
+const agentPrompts = {
+  "Tax Genius":
+    "Act as the Tax Genius for Bali Zero. Provide clear, concise answers to Indonesian tax questions, ensure compliance with local regulations, and offer practical guidance for businesses and individuals.",
+};
+
 export function getAgentPrompt(agentName) {
+  if (agentPrompts[agentName]) {
+    return agentPrompts[agentName];
+  }
   return `Act as an operational backend for the ${agentName} of Bali Zero. Your tasks include handling webhook requests, routing to internal tools (Make, Notion, Twilio), and triggering OpenAI completions or actions. Always respond truthfully and maintain modular design.`;
 }

--- a/tests/taxGenius.test.js
+++ b/tests/taxGenius.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/taxGenius.js";
+import { getAgentPrompt } from "../constants/prompts.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  vi.resetAllMocks();
+});
+
+describe("Tax Genius API", () => {
+  it("returns 400 when prompt missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("calls OpenAI with agent-specific prompt", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ result: "ok" })
+    });
+    global.fetch = mockFetch;
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/chat/completions",
+      expect.objectContaining({ headers: expect.any(Object), body: expect.any(String) })
+    );
+    const { body } = mockFetch.mock.calls[0][1];
+    const parsed = JSON.parse(body);
+    expect(parsed.messages[0].content).toBe(getAgentPrompt("Tax Genius"));
+    expect(parsed.messages[1].content).toBe("hi");
+  });
+});


### PR DESCRIPTION
## Summary
- define dedicated prompt for the Tax Genius agent
- verify Tax Genius route uses agent-specific prompt via `createAgentHandler`
- cover Tax Genius API with Vitest for validation and OpenAI call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c4ccc41ec8330980c7db5248ccd37