### PR TITLE
Add Setup Master prompt and handler test

### DIFF
--- a/constants/prompts.js
+++ b/constants/prompts.js
@@ -1,3 +1,12 @@
+const PROMPTS = {
+  "Setup Master":
+    "Act as the Setup Master for Bali Zero. Provide clear step-by-step guidance for configuration tasks and verify that each component is ready for production.",
+};
+
 export function getAgentPrompt(agentName) {
-  return `Act as an operational backend for the ${agentName} of Bali Zero. Your tasks include handling webhook requests, routing to internal tools (Make, Notion, Twilio), and triggering OpenAI completions or actions. Always respond truthfully and maintain modular design.`;
+  return (
+    PROMPTS[agentName] ||
+    `Act as an operational backend for the ${agentName} of Bali Zero. Your tasks include handling webhook requests, routing to internal tools (Make, Notion, Twilio), and triggering OpenAI completions or actions. Always respond truthfully and maintain modular design.`
+  );
 }
+

--- a/tests/setupMaster.test.js
+++ b/tests/setupMaster.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/setupMaster.js";
+import { getAgentPrompt } from "../constants/prompts.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  global.fetch = vi.fn().mockResolvedValue({
+    json: () => Promise.resolve({ result: "ok" })
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("setupMaster handler", () => {
+  it("returns 200 and logs JSON on success", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
+    const res = httpMocks.createResponse();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+
+    const fetchBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(fetchBody.messages[0].content).toBe(getAgentPrompt("Setup Master"));
+
+    expect(logSpy).toHaveBeenCalled();
+    const parsedLog = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsedLog.action).toBe("success");
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit prompt for Setup Master agent
- test Setup Master handler for successful execution and JSON logging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c4ccb67bc8330adac9bfa02039d4c