### PR TITLE
feat: add Visa Oracle prompt and tests

### DIFF
--- a/constants/prompts.js
+++ b/constants/prompts.js
@@ -1,3 +1,12 @@
 export function getAgentPrompt(agentName) {
-  return `Act as an operational backend for the ${agentName} of Bali Zero. Your tasks include handling webhook requests, routing to internal tools (Make, Notion, Twilio), and triggering OpenAI completions or actions. Always respond truthfully and maintain modular design.`;
+  const prompts = {
+    "Visa Oracle":
+      "As the Visa Oracle for Bali Zero, provide authoritative guidance on Indonesian visa and residency options. Ensure accuracy, mention that regulations may change, and encourage consultation with official sources while maintaining a modular design."
+  };
+
+  return (
+    prompts[agentName] ||
+    `Act as an operational backend for the ${agentName} of Bali Zero. Your tasks include handling webhook requests, routing to internal tools (Make, Notion, Twilio), and triggering OpenAI completions or actions. Always respond truthfully and maintain modular design.`
+  );
 }
+

--- a/tests/visaOracle.test.js
+++ b/tests/visaOracle.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { getAgentPrompt } from "../constants/prompts.js";
+
+const handler = createAgentHandler("Visa Oracle");
+
+describe("visaOracle handler", () => {
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "test";
+  });
+
+  it("calls OpenAI with specialized prompt and returns structured response", async () => {
+    const expectedPrompt = getAgentPrompt("Visa Oracle");
+    const mockOpenAIResponse = {
+      choices: [
+        {
+          message: { role: "assistant", content: "dummy" }
+        }
+      ]
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => mockOpenAIResponse
+    });
+    global.fetch = fetchMock;
+
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { prompt: "Test" }
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+
+    expect(body.messages[0]).toEqual({ role: "system", content: expectedPrompt });
+    expect(body.messages[1]).toEqual({ role: "user", content: "Test" });
+
+    const jsonResponse = JSON.parse(res._getData());
+    expect(res.statusCode).toBe(200);
+    expect(jsonResponse.success).toBe(true);
+    expect(jsonResponse.data).toEqual(mockOpenAIResponse);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add specialized Visa Oracle prompt
- test Visa Oracle handler's OpenAI request and response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c4cc9cc18833096554e82781ca8e7