### PR TITLE
feat: add scraper endpoint with provider fallback

### DIFF
--- a/api/scraper/run.js
+++ b/api/scraper/run.js
@@ -1,0 +1,68 @@
+import { scrape } from "../../helpers/scraper.js";
+import { isBlockedRequester } from "../../helpers/checkBlockedRequester.js";
+import { validateOpenAIKey } from "../../helpers/validateOpenAIKey.js";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ success: false, error: "Method Not Allowed" });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/scraper/run",
+        action: "missingOpenAIKey",
+        status: 500
+      })
+    );
+    return res.status(500).json({ success: false, error: error.message });
+  }
+
+  const { url, options = {}, requester } = req.body || {};
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/scraper/run",
+        action: "blockedRequester",
+        requester
+      })
+    );
+    return res.status(403).json({ success: false, error: "Access denied" });
+  }
+
+  if (!url) {
+    return res.status(400).json({ success: false, error: "Missing url in request body" });
+  }
+
+  try {
+    const result = await scrape(url, options);
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/scraper/run",
+        action: "scrape",
+        status: 200,
+        provider: result.provider,
+        url,
+        userIP: req.headers["x-forwarded-for"]
+      })
+    );
+    return res.status(200).json({ success: true, data: result });
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/scraper/run",
+        action: "scrape",
+        status: 500,
+        error: error.message
+      })
+    );
+    return res.status(500).json({ success: false, error: error.message });
+  }
+}

--- a/helpers/scraper.js
+++ b/helpers/scraper.js
@@ -1,0 +1,58 @@
+export async function scrape(url, options = {}) {
+  if (!url) {
+    throw new Error("URL is required");
+  }
+
+  const apifyToken = process.env.APIFY_TOKEN;
+  const browserlessKey = process.env.BROWSERLESS_KEY;
+
+  if (apifyToken) {
+    try {
+      const apifyResponse = await fetch("https://api.apify.com/v2/browser-info", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apifyToken}`
+        },
+        body: JSON.stringify({ url, options })
+      });
+
+      if (!apifyResponse.ok) {
+        throw new Error("Apify request failed");
+      }
+
+      const data = await apifyResponse.json();
+      return { provider: "apify", data };
+    } catch (error) {
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          provider: "apify",
+          action: "scrape",
+          status: "fallback",
+          error: error.message
+        })
+      );
+    }
+  }
+
+  if (browserlessKey) {
+    const blResponse = await fetch(
+      `https://chrome.browserless.io/content?token=${browserlessKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url, options })
+      }
+    );
+
+    if (!blResponse.ok) {
+      throw new Error("Browserless request failed");
+    }
+
+    const data = await blResponse.json();
+    return { provider: "browserless", data };
+  }
+
+  throw new Error("No scraping provider available");
+}

--- a/tests/scraperRun.test.js
+++ b/tests/scraperRun.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/scraper/run.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test-key";
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  delete process.env.APIFY_TOKEN;
+  delete process.env.BROWSERLESS_KEY;
+});
+
+describe("/api/scraper/run", () => {
+  it("uses Apify when token available", async () => {
+    process.env.APIFY_TOKEN = "apify";
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ result: "apify-data" })
+    });
+
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { url: "http://example.com" }
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res._getData());
+    expect(body.success).toBe(true);
+    expect(body.data.provider).toBe("apify");
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toContain("apify");
+  });
+
+  it("falls back to Browserless when Apify fails", async () => {
+    process.env.APIFY_TOKEN = "apify";
+    process.env.BROWSERLESS_KEY = "browserless";
+    global.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Apify error"))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ result: "browserless-data" })
+      });
+
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { url: "http://example.com" }
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res._getData());
+    expect(body.success).toBe(true);
+    expect(body.data.provider).toBe("browserless");
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls[1][0]).toContain("browserless");
+  });
+});


### PR DESCRIPTION
## Summary
- add scraper helper invoking Apify with Browserless fallback
- expose /api/scraper/run handler with validation and logging
- test scraper success and fallback paths via Vitest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c4cc8b2fc83308bb6c865bd71449b