### PR TITLE
feat: add GitHub webhook handler and client

### DIFF
--- a/api/github/webhook.js
+++ b/api/github/webhook.js
@@ -1,0 +1,162 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { validateOpenAIKey } from "../../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../../helpers/checkBlockedRequester.js";
+
+/**
+ * GitHub webhook handler verifying signatures and respecting Zantara API rules
+ */
+export default async function handler(req, res) {
+  const route = "/api/github/webhook";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
+
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "methodCheck",
+        status: 405,
+        userIP,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "keyValidation",
+        status: 500,
+        userIP,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const secret = process.env.GITHUB_WEBHOOK_SECRET;
+  if (!secret) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "secretCheck",
+        status: 500,
+        userIP,
+        message: "Missing GitHub Webhook Secret"
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Missing GitHub Webhook Secret",
+      error: "Missing GitHub Webhook Secret",
+      nextStep: "Set GITHUB_WEBHOOK_SECRET in environment"
+    });
+  }
+
+  const { requester } = req.body || {};
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "blockedRequester",
+        status: 403,
+        userIP,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  const signature = req.headers["x-hub-signature-256"];
+  if (!signature) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "signatureMissing",
+        status: 400,
+        userIP,
+        message: "Missing signature"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing signature",
+      error: "Missing signature",
+      nextStep: "Include X-Hub-Signature-256 header"
+    });
+  }
+
+  const payload = JSON.stringify(req.body || {});
+  const hmac = createHmac("sha256", secret);
+  const digest = "sha256=" + hmac.update(payload).digest("hex");
+  const signatureBuffer = Buffer.from(signature);
+  const digestBuffer = Buffer.from(digest);
+  const isValid =
+    signatureBuffer.length === digestBuffer.length &&
+    timingSafeEqual(signatureBuffer, digestBuffer);
+
+  if (!isValid) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "signatureVerify",
+        status: 401,
+        userIP,
+        message: "Invalid signature"
+      })
+    );
+    return res.status(401).json({
+      success: false,
+      status: 401,
+      summary: "Invalid signature",
+      error: "Invalid signature"
+    });
+  }
+
+  console.log(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "success",
+      status: 200,
+      userIP,
+      summary: "Webhook received"
+    })
+  );
+
+  return res.status(200).json({
+    success: true,
+    status: 200,
+    summary: "Webhook received",
+    data: { event: req.headers["x-github-event"] }
+  });
+}
+

--- a/helpers/githubClient.js
+++ b/helpers/githubClient.js
@@ -1,0 +1,27 @@
+/**
+ * Minimal GitHub API client authenticated via process.env.GITHUB_TOKEN
+ * @param {string} path - API path starting with '/'
+ * @param {object} options - fetch options
+ */
+export async function githubClient(path, options = {}) {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) {
+    throw new Error("Missing GitHub token");
+  }
+
+  const response = await fetch(`https://api.github.com${path}`, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `token ${token}`,
+      "User-Agent": "zantara-api",
+      ...(options.headers || {})
+    }
+  });
+
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data.message || "GitHub API request failed");
+  }
+  return data;
+}

--- a/tests/githubClient.test.js
+++ b/tests/githubClient.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { githubClient } from "../helpers/githubClient.js";
+
+describe("githubClient", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws when token missing", async () => {
+    delete process.env.GITHUB_TOKEN;
+    await expect(githubClient("/user")).rejects.toThrow("Missing GitHub token");
+  });
+
+  it("adds auth header and returns data", async () => {
+    process.env.GITHUB_TOKEN = "abc123";
+    const mockData = { ok: true };
+    global.fetch = vi.fn(async (url, options) => ({
+      ok: true,
+      json: async () => mockData
+    }));
+    const data = await githubClient("/test");
+    expect(data).toEqual(mockData);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/test",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "token abc123"
+        })
+      })
+    );
+  });
+
+  it("throws on non-ok response", async () => {
+    process.env.GITHUB_TOKEN = "abc123";
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      json: async () => ({ message: "Bad" })
+    }));
+    await expect(githubClient("/bad")).rejects.toThrow("Bad");
+  });
+});

--- a/tests/githubWebhook.test.js
+++ b/tests/githubWebhook.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/github/webhook.js";
+import { createHmac } from "node:crypto";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.GITHUB_WEBHOOK_SECRET = "secret";
+});
+
+describe("github webhook", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when signature missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: {} });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 401 for invalid signature", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { test: true },
+      headers: { "x-hub-signature-256": "sha256=invalid" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 200 for valid signature", async () => {
+    const body = { test: true };
+    const payload = JSON.stringify(body);
+    const signature =
+      "sha256=" +
+      createHmac("sha256", process.env.GITHUB_WEBHOOK_SECRET)
+        .update(payload)
+        .digest("hex");
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body,
+      headers: { "x-hub-signature-256": signature }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add GitHub webhook endpoint with signature verification
- create GitHub API client authenticated via token
- test GitHub webhook handler and client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c4cc7c070833098364193459932df