### PR TITLE
feat: add Canva job queue and polling

### DIFF
--- a/api/canva/generate.js
+++ b/api/canva/generate.js
@@ -1,0 +1,152 @@
+import { validateOpenAIKey } from "../../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../../helpers/checkBlockedRequester.js";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "methodCheck",
+      status: 405,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "keyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  if (!process.env.CANVA_API_KEY) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "canvaKeyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Missing Canva API Key"
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Missing Canva API Key",
+      error: "Missing Canva API Key",
+      nextStep: "Set CANVA_API_KEY in environment"
+    });
+  }
+
+  const { designId, requester } = req.body || {};
+
+  if (!designId) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "bodyValidation",
+      status: 400,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Missing designId in request body"
+    }));
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing designId in request body",
+      error: "Missing designId in request body",
+      nextStep: "Include designId in JSON body"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "blockedRequester",
+      status: 403,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Requester is blocked"
+    }));
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    const response = await fetch("https://api.canva.com/v1/generate", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${process.env.CANVA_API_KEY}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ designId })
+    });
+
+    const data = await response.json().catch(() => ({}));
+
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "queueJob",
+      status: response.status,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      jobId: data.jobId
+    }));
+
+    if (!response.ok) {
+      return res.status(response.status).json({
+        success: false,
+        status: response.status,
+        summary: "Failed to queue job",
+        error: data.error || "Request failed"
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Job queued",
+      data: { jobId: data.jobId }
+    });
+  } catch (error) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/canva/generate",
+      action: "error",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: error.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}
+

--- a/helpers/pollCanvaJobStatus.js
+++ b/helpers/pollCanvaJobStatus.js
@@ -1,0 +1,48 @@
+export async function pollCanvaJobStatus(jobId, { interval = 1000, maxAttempts = 10 } = {}) {
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    route: "helpers/pollCanvaJobStatus",
+    action: "start",
+    jobId
+  }));
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const response = await fetch(`https://api.canva.com/v1/jobs/${jobId}`, {
+        headers: {
+          Authorization: `Bearer ${process.env.CANVA_API_KEY}`
+        }
+      });
+      const data = await response.json();
+      console.log(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "helpers/pollCanvaJobStatus",
+        action: "poll",
+        attempt,
+        jobId,
+        status: data.status
+      }));
+      if (data.status === "completed" || data.status === "failed") {
+        return data;
+      }
+    } catch (error) {
+      console.log(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "helpers/pollCanvaJobStatus",
+        action: "error",
+        jobId,
+        message: error.message
+      }));
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    route: "helpers/pollCanvaJobStatus",
+    action: "timeout",
+    jobId
+  }));
+  throw new Error("Job polling timed out");
+}

--- a/tests/canvaGenerate.test.js
+++ b/tests/canvaGenerate.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/canva/generate.js";
+import { pollCanvaJobStatus } from "../helpers/pollCanvaJobStatus.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.CANVA_API_KEY = "canva";
+});
+
+describe("canva generate handler", () => {
+  it("queues job and returns job ID", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: () => Promise.resolve({ jobId: "job123" })
+    });
+    const req = httpMocks.createRequest({ method: "POST", body: { designId: "d1" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).data.jobId).toBe("job123");
+  });
+});
+
+describe("pollCanvaJobStatus", () => {
+  it("retrieves completed status", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ status: "pending" }) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ status: "completed" }) });
+    global.fetch = fetchMock;
+    const result = await pollCanvaJobStatus("job123", { interval: 1, maxAttempts: 5 });
+    expect(result.status).toBe("completed");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/canva/generate` endpoint to queue Canva jobs
- introduce `pollCanvaJobStatus` helper for async job polling
- cover job submission and status retrieval with Vitest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c4cc64f488330b6fb4b4baac22340