### PR TITLE
feat: secure notion write endpoint

### DIFF
--- a/api/notion-write.js
+++ b/api/notion-write.js
@@ -1,30 +1,145 @@
 import { Client } from "@notionhq/client";
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
 
 const notion = new Client({ auth: process.env.NOTION_TOKEN });
 
 export default async function handler(req, res) {
+  const route = "/api/notion-write";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
+
   if (req.method !== "POST") {
-    return res.status(405).json({ message: "Method Not Allowed" });
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "methodCheck",
+        status: 405,
+        userIP,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
   }
 
-  const { request, summary } = req.body;
+  const authHeader = req.headers["authorization"];
+  if (!authHeader || authHeader !== `Bearer ${process.env.ZANTARA_API_KEY}`) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "authCheck",
+        status: 401,
+        userIP,
+        message: "Unauthorized"
+      })
+    );
+    return res.status(401).json({
+      success: false,
+      status: 401,
+      summary: "Unauthorized",
+      error: "Unauthorized",
+      nextStep: "Provide a valid Authorization header"
+    });
+  }
+
+  const { request, summary } = req.body || {};
+  if (!request || !summary) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "validation",
+        status: 400,
+        userIP,
+        message: "Missing request or summary"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing request or summary",
+      error: "Missing request or summary",
+      nextStep: "Include request and summary"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "keyValidation",
+        status: 500,
+        userIP,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
 
   try {
     const response = await notion.pages.create({
       parent: { database_id: process.env.NOTION_DATABASE_ID },
       properties: {
         Request: {
-          title: [{ text: { content: request } }],
+          title: [{ text: { content: request } }]
         },
         "Response Summary": {
-          rich_text: [{ text: { content: summary || "N/A" } }],
-        },
-      },
+          rich_text: [{ text: { content: summary } }]
+        }
+      }
     });
 
-    return res.status(200).json({ message: "Success", data: response });
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "success",
+        status: 200,
+        userIP,
+        summary: "Request saved to Notion"
+      })
+    );
+
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Request saved to Notion",
+      data: response
+    });
   } catch (error) {
     console.error("Notion error:", error);
-    return res.status(500).json({ message: "Internal Server Error", error: error.message });
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "error",
+        status: 500,
+        userIP,
+        message: "Internal Server Error"
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
   }
 }
+

--- a/tests/notionWrite.test.js
+++ b/tests/notionWrite.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+
+let handler;
+let createMock;
+
+vi.mock("@notionhq/client", () => {
+  return {
+    Client: class {
+      constructor() {
+        createMock = vi.fn().mockResolvedValue({ id: "mock-page" });
+        this.pages = { create: createMock };
+      }
+    }
+  };
+});
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env.ZANTARA_API_KEY = "valid";
+  process.env.OPENAI_API_KEY = "openai";
+  process.env.NOTION_DATABASE_ID = "db";
+  process.env.NOTION_TOKEN = "token";
+  handler = (await import("../api/notion-write.js")).default;
+});
+
+describe("notion-write API", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 401 when Authorization header invalid", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      body: { request: "test", summary: "sum" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 400 when request or summary missing", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      headers: { authorization: "Bearer valid" },
+      body: { request: "only" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 200 on success", async () => {
+    const req = httpMocks.createRequest({
+      method: "POST",
+      headers: { authorization: "Bearer valid" },
+      body: { request: "test", summary: "sum" }
+    });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+    expect(createMock).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add method, auth, and body validation to `/api/notion-write`
- verify OpenAI key before writing to Notion and log structured JSON
- add tests for notion write handler covering success and error cases

## Testing
- `npm test` (fails: Cannot find module '../pages/api/webhooks/meta/whatsapp.js')
- `npx vitest run tests/notionWrite.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ae2a6b3a883309f0c2cd0cdf8bb1d