### PR TITLE
Add Notion posting helper with unit tests

### DIFF
--- a/helpers/postToNotion.js
+++ b/helpers/postToNotion.js
@@ -1,0 +1,43 @@
+export async function postToNotion({ request, summary }) {
+  const token = process.env.ZANTARA_API_KEY;
+  try {
+    const response = await fetch("/api/notion-write", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ summary })
+    });
+
+    const json = await response.json();
+
+    const log = {
+      timestamp: new Date().toISOString(),
+      route: "/api/notion-write",
+      status: response.status
+    };
+    const userIP = request?.headers?.["x-forwarded-for"];
+    if (userIP) {
+      log.userIP = userIP;
+    }
+    console.log(JSON.stringify(log));
+
+    if (json.success) {
+      return { success: true, data: json.data };
+    }
+    return { success: false, error: json.error };
+  } catch (error) {
+    const log = {
+      timestamp: new Date().toISOString(),
+      route: "/api/notion-write",
+      status: 500
+    };
+    const userIP = request?.headers?.["x-forwarded-for"];
+    if (userIP) {
+      log.userIP = userIP;
+    }
+    console.log(JSON.stringify(log));
+    return { success: false, error: error.message };
+  }
+}

--- a/tests/postToNotion.test.js
+++ b/tests/postToNotion.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { postToNotion } from "../helpers/postToNotion.js";
+
+beforeEach(() => {
+  process.env.ZANTARA_API_KEY = "key";
+});
+
+describe("postToNotion", () => {
+  it("returns data on success", async () => {
+    const mockRes = { success: true, data: { id: "123" } };
+    global.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve(mockRes)
+    });
+
+    const req = httpMocks.createRequest({ headers: { "x-forwarded-for": "1.1.1.1" } });
+    const result = await postToNotion({ request: req, summary: "test" });
+
+    expect(result).toEqual({ success: true, data: mockRes.data });
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/notion-write",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${process.env.ZANTARA_API_KEY}`
+        })
+      })
+    );
+  });
+
+  it("returns error on unauthorized", async () => {
+    const mockRes = { success: false, error: "Unauthorized" };
+    global.fetch = vi.fn().mockResolvedValue({
+      status: 401,
+      json: () => Promise.resolve(mockRes)
+    });
+
+    const req = httpMocks.createRequest();
+    const result = await postToNotion({ request: req, summary: "test" });
+
+    expect(result).toEqual({ success: false, error: mockRes.error });
+  });
+});


### PR DESCRIPTION
## Summary
- add `postToNotion` helper for writing summaries to Notion with structured logging
- cover success and unauthorized cases with unit tests

## Testing
- `npm test` *(fails: Cannot find module '../pages/api/webhooks/meta/whatsapp.js')*
- `npx vitest tests/postToNotion.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689ae2a4ef44833094aae0132de0c4bf