### PR TITLE
Add structured logging and tests for Notion write handler

### DIFF
--- a/api/notion-write.js
+++ b/api/notion-write.js
@@ -1,13 +1,102 @@
 import { Client } from "@notionhq/client";
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
 
 const notion = new Client({ auth: process.env.NOTION_TOKEN });
 
 export default async function handler(req, res) {
+  const route = "/api/notion-write";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
+
+  console.log(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "requestStart",
+      status: 200,
+      userIP
+    })
+  );
+
   if (req.method !== "POST") {
-    return res.status(405).json({ message: "Method Not Allowed" });
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "methodCheck",
+        status: 405,
+        userIP,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed"
+    });
   }
 
-  const { request, summary } = req.body;
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "keyValidation",
+        status: 500,
+        userIP,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message
+    });
+  }
+
+  const { request, summary, requester } = req.body || {};
+
+  if (!request) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "requestValidation",
+        status: 400,
+        userIP,
+        message: "Missing request in body"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing request in body",
+      error: "Missing request in body"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "blockedRequester",
+        status: 403,
+        userIP,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
 
   try {
     const response = await notion.pages.create({
@@ -22,9 +111,40 @@ export default async function handler(req, res) {
       },
     });
 
-    return res.status(200).json({ message: "Success", data: response });
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "createPage",
+        status: 200,
+        userIP,
+        summary: "Page created"
+      })
+    );
+
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Page created",
+      error: null,
+      data: response
+    });
   } catch (error) {
-    console.error("Notion error:", error);
-    return res.status(500).json({ message: "Internal Server Error", error: error.message });
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "error",
+        status: 500,
+        userIP,
+        message: error.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: error.message
+    });
   }
 }

--- a/tests/notionWrite.test.js
+++ b/tests/notionWrite.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+
+vi.mock("@notionhq/client", () => {
+  return {
+    Client: vi.fn().mockImplementation(() => ({
+      pages: {
+        create: vi.fn().mockResolvedValue({ id: "page-id" })
+      }
+    }))
+  };
+});
+
+import handler from "../api/notion-write.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.NOTION_TOKEN = "test";
+  process.env.NOTION_DATABASE_ID = "db";
+});
+
+describe("notion-write handler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(false);
+    expect(data.summary).toBe("Method Not Allowed");
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST", body: { request: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(false);
+    expect(data.summary).toBe("Missing OpenAI API Key");
+  });
+
+  it("returns 200 on success", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { request: "hi", summary: "sum" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+    expect(data.summary).toBe("Page created");
+    expect(data.error).toBeNull();
+    expect(data.data).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add JSON-formatted logs for request start, method checks, key validation, page creation, and errors in Notion write handler
- standardize handler responses with `success`, `status`, `summary`, and `error` fields
- cover Notion write handler with tests for method validation, missing credentials, and successful page creation

## Testing
- `npm test` *(fails: Cannot find module '../pages/api/webhooks/meta/whatsapp.js')*
- `npx vitest run tests/notionWrite.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689ac66ff0008330b0e187117e744c7f