### PR TITLE
feat: harden Notion callback handler

### DIFF
--- a/api/notion/callback.js
+++ b/api/notion/callback.js
@@ -1,23 +1,62 @@
 import axios from 'axios';
 
 export default async function handler(req, res) {
-  const { code } = req.query;
+  const route = "/api/notion/callback";
 
-  if (!code || typeof code !== 'string') {
-    return res.status(400).json({ error: 'Missing or invalid `code` parameter' });
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "methodCheck",
+      status: 405,
+      method: req.method,
+      userIP: req.headers["x-forwarded-for"],
+    }));
+    return res.status(405).json({ success: false, error: "Method Not Allowed" });
   }
 
-  console.log("🔐 ENV VARIABLES CHECK:");
+  if (!process.env.OPENAI_API_KEY) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "envCheck",
+      status: 500,
+      message: "Missing OpenAI API Key",
+      userIP: req.headers["x-forwarded-for"],
+    }));
+    return res.status(500).json({ success: false, error: "Missing OpenAI API Key" });
+  }
+
+  const { code } = req.query;
+
+  if (!code || typeof code !== "string") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "validateCode",
+      status: 400,
+      message: "Missing or invalid `code` parameter",
+      userIP: req.headers["x-forwarded-for"],
+    }));
+    return res.status(400).json({ success: false, error: "Missing or invalid `code` parameter" });
+  }
+
   const notionToken = process.env.NOTION_TOKEN;
   const notionDatabaseId = process.env.NOTION_DATABASE_ID;
 
   if (!notionToken || !notionDatabaseId) {
-    console.error("❌ Missing NOTION_TOKEN or NOTION_DATABASE_ID");
-    return res.status(500).json({ error: "Missing environment variables" });
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "envCheck",
+      status: 500,
+      message: "Missing NOTION_TOKEN or NOTION_DATABASE_ID",
+      userIP: req.headers["x-forwarded-for"],
+    }));
+    return res.status(500).json({ success: false, error: "Missing environment variables" });
   }
 
   try {
-    // 🔄 Optional: trasformazione del codice in contenuto Notion
     const newEntry = {
       parent: { database_id: notionDatabaseId },
       properties: {
@@ -39,11 +78,25 @@ export default async function handler(req, res) {
       }
     );
 
-    console.log("✅ Entry saved to Notion:", notionRes.data.id);
-    return res.status(200).json({ success: true, notionPageId: notionRes.data.id });
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "saveToNotion",
+      status: 200,
+      notionPageId: notionRes.data.id,
+      userIP: req.headers["x-forwarded-for"],
+    }));
+    return res.status(200).json({ success: true, data: { notionPageId: notionRes.data.id } });
 
   } catch (error) {
-    console.error("❌ Error saving to Notion:", error.response?.data || error.message);
-    return res.status(500).json({ error: "Failed to save to Notion" });
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "saveToNotion",
+      status: 500,
+      error: error.response?.data || error.message,
+      userIP: req.headers["x-forwarded-for"],
+    }));
+    return res.status(500).json({ success: false, error: "Failed to save to Notion" });
   }
 }

--- a/tests/notionCallback.test.js
+++ b/tests/notionCallback.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+
+vi.mock("axios", () => ({ default: { post: vi.fn() } }));
+import handler from "../api/notion/callback.js";
+import axios from "axios";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.NOTION_TOKEN = "token";
+  process.env.NOTION_DATABASE_ID = "db";
+  axios.post.mockReset();
+});
+
+describe("notion callback handler", () => {
+  it("returns 200 for valid code", async () => {
+    axios.post.mockResolvedValue({ data: { id: "abc123" } });
+    const req = httpMocks.createRequest({ method: "POST", query: { code: "123" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+    expect(data.data.notionPageId).toBe("abc123");
+  });
+
+  it("returns 400 for invalid code", async () => {
+    const req = httpMocks.createRequest({ method: "POST", query: { code: 123 } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- validate POST method and environment keys in Notion callback
- add structured JSON logs and consistent error handling
- cover Notion callback for valid and invalid codes

## Testing
- `npm test` *(fails: Cannot find module '../pages/api/webhooks/meta/whatsapp.js' imported from '/workspace/zantara-api/tests/whatsappWebhook.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_689ac66c8684833081da6a226b845984