### PR TITLE
chore: standardize error logs

### DIFF
--- a/api/notion-write.js
+++ b/api/notion-write.js
@@ -24,7 +24,15 @@ export default async function handler(req, res) {
 
     return res.status(200).json({ message: "Success", data: response });
   } catch (error) {
-    console.error("Notion error:", error);
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion-write",
+        action: "error",
+        status: 500,
+        message: error.message
+      })
+    );
     return res.status(500).json({ message: "Internal Server Error", error: error.message });
   }
 }

--- a/api/notion/callback.js
+++ b/api/notion/callback.js
@@ -7,12 +7,28 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: 'Missing or invalid `code` parameter' });
   }
 
-  console.log("🔐 ENV VARIABLES CHECK:");
+  console.log(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/notion/callback",
+      action: "envCheck",
+      status: 200,
+      message: "Checking environment variables"
+    })
+  );
   const notionToken = process.env.NOTION_TOKEN;
   const notionDatabaseId = process.env.NOTION_DATABASE_ID;
 
   if (!notionToken || !notionDatabaseId) {
-    console.error("❌ Missing NOTION_TOKEN or NOTION_DATABASE_ID");
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion/callback",
+        action: "error",
+        status: 500,
+        message: "Missing NOTION_TOKEN or NOTION_DATABASE_ID"
+      })
+    );
     return res.status(500).json({ error: "Missing environment variables" });
   }
 
@@ -39,11 +55,27 @@ export default async function handler(req, res) {
       }
     );
 
-    console.log("✅ Entry saved to Notion:", notionRes.data.id);
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion/callback",
+        action: "success",
+        status: 200,
+        message: `Entry saved to Notion: ${notionRes.data.id}`
+      })
+    );
     return res.status(200).json({ success: true, notionPageId: notionRes.data.id });
 
   } catch (error) {
-    console.error("❌ Error saving to Notion:", error.response?.data || error.message);
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion/callback",
+        action: "error",
+        status: 500,
+        message: error.message
+      })
+    );
     return res.status(500).json({ error: "Failed to save to Notion" });
   }
 }

--- a/handlers/createAgentHandler.js
+++ b/handlers/createAgentHandler.js
@@ -116,15 +116,16 @@ export function createAgentHandler(agentName) {
         data
       });
     } catch (error) {
-      console.error("Error fetching data from OpenAI:", error);
-      console.log(JSON.stringify({
-        timestamp: new Date().toISOString(),
-        route: `/api/${agentName}`,
-        action: "error",
-        status: 500,
-        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
-        message: "Internal Server Error"
-      }));
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route: `/api/${agentName}`,
+          action: "error",
+          status: 500,
+          userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+          message: error.message
+        })
+      );
       return res.status(500).json({
         success: false,
         status: 500,

--- a/handlers/testTriggerHandler.js
+++ b/handlers/testTriggerHandler.js
@@ -94,22 +94,23 @@ export async function testTriggerHandler(req, res) {
       summary: "Webhook triggered",
       data
     });
-  } catch (error) {
-    console.error("Error triggering webhook:", error);
-    console.log(JSON.stringify({
-      timestamp: new Date().toISOString(),
-      route: "/api/make/test-trigger",
-      action: "error",
-      status: 500,
-      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
-      message: "Internal Server Error"
-    }));
-    return res.status(500).json({
-      success: false,
-      status: 500,
-      summary: "Internal Server Error",
-      error: "Internal Server Error",
-      nextStep: "Check server logs and retry"
-    });
-  }
+    } catch (error) {
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route: "/api/make/test-trigger",
+          action: "error",
+          status: 500,
+          userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+          message: error.message
+        })
+      );
+      return res.status(500).json({
+        success: false,
+        status: 500,
+        summary: "Internal Server Error",
+        error: "Internal Server Error",
+        nextStep: "Check server logs and retry"
+      });
+    }
 }

--- a/handlers/triggerScenarioHandler.js
+++ b/handlers/triggerScenarioHandler.js
@@ -94,22 +94,23 @@ export async function triggerScenarioHandler(req, res) {
       summary: "Scenario triggered",
       data
     });
-  } catch (error) {
-    console.error("Error triggering scenario:", error);
-    console.log(JSON.stringify({
-      timestamp: new Date().toISOString(),
-      route: "/api/make/trigger-scenario",
-      action: "error",
-      status: 500,
-      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
-      message: "Internal Server Error"
-    }));
-    return res.status(500).json({
-      success: false,
-      status: 500,
-      summary: "Internal Server Error",
-      error: "Internal Server Error",
-      nextStep: "Check server logs and retry"
-    });
-  }
+    } catch (error) {
+      console.log(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route: "/api/make/trigger-scenario",
+          action: "error",
+          status: 500,
+          userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+          message: error.message
+        })
+      );
+      return res.status(500).json({
+        success: false,
+        status: 500,
+        summary: "Internal Server Error",
+        error: "Internal Server Error",
+        nextStep: "Check server logs and retry"
+      });
+    }
 }


### PR DESCRIPTION
## Summary
- log errors in JSON format with timestamps, routes and messages
- remove plain text logs and adopt structured logging for Notion callbacks

## Testing
- `npx --yes vitest` *(fails: Cannot find package 'node-mocks-http')*

------
https://chatgpt.com/codex/tasks/task_e_689a5ba988d48330b2d3480074fb569d