### PR TITLE
Require MAKE_API_TOKEN for Make webhook calls

### DIFF
--- a/Readme final
+++ b/Readme final
@@ -68,10 +68,17 @@
 ---
 
 ## ✨ 9. Output
-- Le risposte JSON devono sempre contenere almeno:
-  - `success: true/false`
-  - `data` o `error`
-- Evitare risposte verbose, a meno che non sia richiesto
+  - Le risposte JSON devono sempre contenere almeno:
+    - `success: true/false`
+    - `data` o `error`
+  - Evitare risposte verbose, a meno che non sia richiesto
+
+## 🌐 Environment Variables
+
+| Variable | Description |
+| -------- | ----------- |
+| `OPENAI_API_KEY` | Secret key for accessing the OpenAI API. Must be defined in your environment (e.g., Vercel, .env file) |
+| `MAKE_API_TOKEN` | Token required for authenticating requests to Make.com webhooks |
 
 ---
 

--- a/constants/make.js
+++ b/constants/make.js
@@ -1,1 +1,2 @@
-export const DEFAULT_MAKE_API_TOKEN = "44d53bf9-799a-4e41-8b2f-3585fa2b7bfd";
+// Placeholder token; real value must be provided via MAKE_API_TOKEN environment variable
+export const DEFAULT_MAKE_API_TOKEN = "";

--- a/helpers/postToWebhook.js
+++ b/helpers/postToWebhook.js
@@ -1,7 +1,15 @@
-import { DEFAULT_MAKE_API_TOKEN } from "../constants/make.js";
-
 export async function postToWebhook(url, payload) {
-  const token = process.env.MAKE_API_TOKEN || DEFAULT_MAKE_API_TOKEN;
+  const token = process.env.MAKE_API_TOKEN;
+  if (!token) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      action: "missingMakeToken",
+      status: 500
+    }));
+    const error = new Error("Missing Make API Token");
+    error.statusCode = 500;
+    throw error;
+  }
   const response = await fetch(url, {
     method: "POST",
     headers: {

--- a/lib/makeTrigger.js
+++ b/lib/makeTrigger.js
@@ -1,5 +1,3 @@
-import { DEFAULT_MAKE_API_TOKEN } from "../constants/make.js";
-
 /**
  * Trigger a Make webhook with optional payload.
  * @param {Object} data Optional data to send in request body
@@ -7,7 +5,15 @@ import { DEFAULT_MAKE_API_TOKEN } from "../constants/make.js";
  */
 export async function triggerMakeWebhook(data = {}) {
   const url = process.env.MAKE_WEBHOOK_URL || "https://example.com";
-  const token = process.env.MAKE_API_TOKEN || DEFAULT_MAKE_API_TOKEN;
+  const token = process.env.MAKE_API_TOKEN;
+  if (!token) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      action: "missingMakeToken",
+      status: 500
+    }));
+    throw new Error("Missing Make API Token");
+  }
   const payload = Object.keys(data).length ? data : { module: "Zantara", status: "ACTIVE" };
 
   const response = await fetch(url, {

--- a/tests/makeTrigger.test.js
+++ b/tests/makeTrigger.test.js
@@ -1,5 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { triggerMakeWebhook } from "../lib/makeTrigger.js";
+
+beforeEach(() => {
+  process.env.MAKE_API_TOKEN = "test-token";
+});
+
+afterEach(() => {
+  delete process.env.MAKE_API_TOKEN;
+  vi.restoreAllMocks();
+});
 
 describe("ZANTARA > triggerMakeWebhook", () => {
   it("should send default payload to Make webhook", async () => {
@@ -17,8 +26,12 @@ describe("ZANTARA > triggerMakeWebhook", () => {
     expect(result).toBeDefined();
   });
 
+  it("should throw an error when token missing", async () => {
+    delete process.env.MAKE_API_TOKEN;
+    await expect(triggerMakeWebhook()).rejects.toThrow("Missing Make API Token");
+  });
+
   it("should throw an error for invalid URL", async () => {
-    // Override temporarily
     const originalURL = global.fetch;
     global.fetch = () => Promise.resolve({ ok: false, status: 400, text: () => "Bad Request" });
 

--- a/tests/testTriggerHandler.test.js
+++ b/tests/testTriggerHandler.test.js
@@ -22,6 +22,14 @@ describe("testTriggerHandler", () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it("returns 500 when Make token missing", async () => {
+    delete process.env.MAKE_API_TOKEN;
+    const req = httpMocks.createRequest({ method: "POST", body: { webhook_url: "url", payload: {} } });
+    const res = httpMocks.createResponse();
+    await testTriggerHandler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
   it("returns 200 on success", async () => {
     global.fetch = vi.fn().mockResolvedValue({ json: () => Promise.resolve({ result: "ok" }) });
     const req = httpMocks.createRequest({ method: "POST", body: { webhook_url: "url", payload: {} } });

--- a/tests/triggerScenarioHandler.test.js
+++ b/tests/triggerScenarioHandler.test.js
@@ -30,6 +30,14 @@ describe("triggerScenarioHandler", () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it("returns 500 when Make token missing", async () => {
+    delete process.env.MAKE_API_TOKEN;
+    const req = httpMocks.createRequest({ method: "POST", body: { scenario_id: "1", webhook_url: "url", payload: {} } });
+    const res = httpMocks.createResponse();
+    await triggerScenarioHandler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
   it("returns 403 for blocked requester", async () => {
     const req = httpMocks.createRequest({ method: "POST", body: { scenario_id: "1", webhook_url: "url", payload: {}, requester: "Ruslantara" } });
     const res = httpMocks.createResponse();


### PR DESCRIPTION
## Summary
- remove hard-coded Make.com token and use env var
- enforce MAKE_API_TOKEN in webhook helper and trigger library
- document MAKE_API_TOKEN setup requirement

## Testing
- `NODE_PATH=$(npm root -g) vitest run tests/makeTrigger.test.js tests/testTriggerHandler.test.js tests/triggerScenarioHandler.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689a58eda94083309e34b037a16544f8