### PR TITLE
feat: add ZION orchestrator scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+ZION_ACTION_KEY=changeme
+NOTION_TOKEN=changeme
+DEFAULT_NOTION_LOG_DB=changeme
+
+# Deleghe Make
+USE_MAKE_DELEGATION=true
+MAKE_WEBHOOK_URL=changeme
+MAKE_WEBHOOK_SECRET=changeme
+
+# Opzionali per provider diretti
+GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account",...}
+GOOGLE_IMPERSONATE_USER=ops@company.com
+GMAIL_FROM=ops@company.com
+
+# WhatsApp Cloud
+WHATSAPP_TOKEN=EAAG...
+WHATSAPP_PHONE_NUMBER_ID=123456789
+
+# Notion (bootstrap opzionale)
+NOTION_PARENT_PAGE_ID=<PageID se vuoi creare i DB automaticamente>

--- a/agents/INSTRUCTIONS_ONELINER.md
+++ b/agents/INSTRUCTIONS_ONELINER.md
@@ -1,0 +1,1 @@
+When operational work is required, output ONE strict JSON envelope in the ZION spec and CALL the Action “ZION API → sendZionCommand”. Do not ask for confirmation. If data is missing, output the same envelope with status "waiting_for_data" and a `missing` array. Set `meta.source_agent` to your agent name.

--- a/gpt/knowledge/agents.yaml
+++ b/gpt/knowledge/agents.yaml
@@ -1,0 +1,9 @@
+agents:
+  - Zantara
+  - Visa Oracle
+  - Setup Master
+  - The Legal Architect
+  - Tax Genius
+  - Notion Keeper
+  - Morgana
+  - NuZantara

--- a/gpt/knowledge/defaults.json
+++ b/gpt/knowledge/defaults.json
@@ -1,0 +1,5 @@
+{
+  "timezone_default": "Asia/Jakarta",
+  "calendar_description_suffix": " — logged by ZION",
+  "whatsapp_prefix": "ZION:"
+}

--- a/gpt/knowledge/notion_schema.md
+++ b/gpt/knowledge/notion_schema.md
@@ -1,0 +1,40 @@
+# Notion Schema
+
+## ZION • Tasks
+- Name (title)
+- Status (select: Inbox, Doing, Blocked, Done)
+- Priority (select: Low, Medium, High, Urgent)
+- Due (date)
+- Agent (select)
+- Project (relation)
+- External ID (rich_text)
+- Make Run ID (rich_text)
+- Last Result (rich_text)
+
+## ZION • Meetings
+- Title (title)
+- Start (date)
+- End (date)
+- Attendees (text)
+- Calendar Event ID (rich_text)
+- External ID (rich_text)
+- Status (select)
+- Task (relation)
+
+## ZION • Logs
+- Name (title)
+- Level (select: info, warning, error)
+- Request ID (rich_text)
+- Action (select)
+- Data (text)
+- Agent (select)
+- Linked Task (relation)
+
+## ZION • Projects
+- Name (title)
+
+## ZION • Contacts
+- Name (title)
+
+## ZION • Scenarios
+- Name (title)

--- a/gpt/knowledge/zion_routing.json
+++ b/gpt/knowledge/zion_routing.json
@@ -1,0 +1,13 @@
+{
+  "notion": {
+    "tasks_db_id": "",
+    "meetings_db_id": "",
+    "logs_db_id": "",
+    "projects_db_id": "",
+    "contacts_db_id": "",
+    "scenarios_db_id": ""
+  },
+  "drive": {
+    "root_folder_id": ""
+  }
+}

--- a/gpt/openapi.zion.json
+++ b/gpt/openapi.zion.json
@@ -1,0 +1,58 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "ZION API", "version": "1.0.0" },
+  "servers": [{ "url": "https://example.com/api" }],
+  "paths": {
+    "/zion": {
+      "post": {
+        "operationId": "sendZionCommand",
+        "summary": "Execute ZION command",
+        "security": [{ "ZionKey": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["action","payload"],
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "notion.create_page","notion.update_page","notion.query_database","notion.append_block",
+                      "drive.create_folder","drive.create_doc_from_text","drive.upload_file_base64","drive.move","drive.share",
+                      "calendar.create_event","email.send_gmail","whatsapp.send_text","log.write"
+                    ]
+                  },
+                  "payload": { "type": "object" },
+                  "meta": {
+                    "type": "object",
+                    "properties": {
+                      "request_id": { "type": "string" },
+                      "source_agent": { "type": "string" },
+                      "dry_run": { "type": "boolean" },
+                      "ts": { "type": "string" },
+                      "log_to_notion": { "type": "boolean" },
+                      "require_approval": { "type": "boolean" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Command executed" },
+          "400": { "description": "Bad request" },
+          "401": { "description": "Unauthorized" },
+          "500": { "description": "Server error" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ZionKey": { "type": "apiKey", "in": "header", "name": "x-zion-key" }
+    }
+  }
+}

--- a/make/zion-router-blueprint.json
+++ b/make/zion-router-blueprint.json
@@ -1,0 +1,21 @@
+{
+  "name": "ZION Router Blueprint",
+  "version": 1,
+  "triggers": [
+    {
+      "type": "webhook",
+      "name": "ZionWebhook",
+      "options": {
+        "customHeaders": ["x-zion-signature"],
+        "verifyHMAC": true,
+        "dedupKey": "meta.request_id"
+      }
+    }
+  ],
+  "routes": [
+    { "action": "calendar.create_event", "modules": ["Google Calendar", "Notion", "Logs"] },
+    { "action": "email.send_gmail", "modules": ["Gmail", "Logs"] },
+    { "action": "drive.*", "modules": ["Google Drive", "Logs"] },
+    { "action": "log.write", "modules": ["Logs"] }
+  ]
+}

--- a/pages/api/zion.ts
+++ b/pages/api/zion.ts
@@ -1,0 +1,141 @@
+import { Client } from "@notionhq/client";
+
+export default async function handler(req, res) {
+  const route = "/api/zion";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
+
+  if (!process.env.OPENAI_API_KEY) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "keyValidation",
+      status: 500,
+      userIP,
+      message: "Missing OpenAI API Key"
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Missing OpenAI API Key",
+      error: "Missing OpenAI API Key",
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  if (req.method === "GET") {
+    const baseUrl = `https://${req.headers.host}/api`;
+    const endpoint = `${baseUrl}/zion`;
+    return res.status(200).json({
+      ok: true,
+      base_url: baseUrl,
+      endpoint,
+      ts: new Date().toISOString()
+    });
+  }
+
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "methodCheck",
+      status: 405,
+      userIP,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Use GET or POST"
+    });
+  }
+
+  if (req.headers["x-zion-key"] !== process.env.ZION_ACTION_KEY) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "auth",
+      status: 401,
+      userIP,
+      message: "Invalid key"
+    }));
+    return res.status(401).json({
+      success: false,
+      status: 401,
+      summary: "Unauthorized",
+      error: "Unauthorized"
+    });
+  }
+
+  const { action, payload, meta = {} } = req.body || {};
+
+  if (!action || !payload) {
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing action or payload",
+      error: "Missing action or payload"
+    });
+  }
+
+  try {
+    const start = Date.now();
+    let data = {};
+
+    if (action === "log.write") {
+      console.log(JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "log.write",
+        status: 200,
+        userIP,
+        meta,
+        payload
+      }));
+      data = { logged: true };
+    } else if (action === "notion.create_page") {
+      const notion = new Client({ auth: process.env.NOTION_TOKEN });
+      data = await notion.pages.create(payload);
+    } else {
+      return res.status(400).json({
+        success: false,
+        status: 400,
+        summary: "Unsupported action",
+        error: "Unsupported action"
+      });
+    }
+
+    const duration = Date.now() - start;
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action,
+      status: 200,
+      userIP,
+      duration
+    }));
+
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Action executed",
+      data
+    });
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "error",
+      status: 500,
+      userIP,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: err.message
+    });
+  }
+}

--- a/scripts/bootstrap-notion.ts
+++ b/scripts/bootstrap-notion.ts
@@ -1,0 +1,47 @@
+import { Client } from "@notionhq/client";
+import fs from "fs";
+import path from "path";
+
+async function main() {
+  const notion = new Client({ auth: process.env.NOTION_TOKEN });
+  const routingPath = path.join(process.cwd(), "gpt/knowledge/zion_routing.json");
+
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    action: "bootstrap-notion",
+    status: "starting"
+  }));
+
+  const routing = {
+    notion: {
+      tasks_db_id: process.env.TASKS_DB_ID || "",
+      meetings_db_id: process.env.MEETINGS_DB_ID || "",
+      logs_db_id: process.env.DEFAULT_NOTION_LOG_DB || "",
+      projects_db_id: process.env.PROJECTS_DB_ID || "",
+      contacts_db_id: process.env.CONTACTS_DB_ID || "",
+      scenarios_db_id: process.env.SCENARIOS_DB_ID || ""
+    },
+    drive: {
+      root_folder_id: process.env.DRIVE_ROOT_FOLDER_ID || ""
+    }
+  };
+
+  fs.writeFileSync(routingPath, JSON.stringify(routing, null, 2));
+
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    action: "bootstrap-notion",
+    status: "completed",
+    routingPath
+  }));
+}
+
+main().catch(err => {
+  console.error(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    action: "bootstrap-notion",
+    status: "error",
+    error: err.message
+  }));
+  process.exit(1);
+});

--- a/scripts/deploy-and-report.mjs
+++ b/scripts/deploy-and-report.mjs
@@ -1,0 +1,18 @@
+import fs from "fs";
+
+async function main() {
+  const domain = process.env.VERCEL_URL || "example.vercel.app";
+  const baseUrl = `https://${domain}/api`;
+  const endpoint = `${baseUrl}/zion`;
+
+  const openapiPath = "gpt/openapi.zion.json";
+  const spec = JSON.parse(fs.readFileSync(openapiPath, "utf-8"));
+  spec.servers = [{ url: baseUrl }];
+  fs.writeFileSync(openapiPath, JSON.stringify(spec, null, 2));
+
+  console.log(`ZION_ENDPOINT=${endpoint}`);
+  console.log(`ZION_SERVERS_URL=${baseUrl}`);
+  console.log(`OPENAPI_PATH=/gpt/openapi.zion.json`);
+}
+
+main();

--- a/tests/zion.test.ts
+++ b/tests/zion.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../pages/api/zion.ts";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.ZION_ACTION_KEY = "secret";
+});
+
+describe("ZION endpoint", () => {
+  it("returns healthcheck on GET", async () => {
+    const req = httpMocks.createRequest({ method: "GET", headers: { host: "example.com" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.ok).toBe(true);
+  });
+
+  it("requires auth", async () => {
+    const req = httpMocks.createRequest({ method: "POST", headers: { "x-zion-key": "wrong" }, body: { action: "log.write", payload: {}, meta: {} } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("handles log.write", async () => {
+    const req = httpMocks.createRequest({ method: "POST", headers: { "x-zion-key": "secret" }, body: { action: "log.write", payload: { level: "info" }, meta: {} } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/zion` endpoint with key auth, logging, and basic Notion integration
- include deployment scripts, knowledge pack, OpenAPI spec, and Make blueprint
- add unit tests for ZION handler

## Testing
- `npx vitest run tests/zion.test.ts`
- `npx vitest run` *(fails: Parse failure: Expected ',' got 'string literal (Notion-Version, "Notion-Version")' in handlers/createAgentHandler.js)*

------
https://chatgpt.com/codex/tasks/task_e_6899b0b16ac88330840883acc08141de