### PR TITLE
Fix Notion-Version header placement in agent requests

### DIFF
--- a/api/zantara.js
+++ b/api/zantara.js
@@ -106,8 +106,10 @@ export default async function handler(req, res) {
       try {
         const response = await fetch(`${baseUrl}/api/${agent}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          "Notion-Version": "2022-06-28"
+          headers: {
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28"
+          },
           body: JSON.stringify({ prompt, requester })
         });
         results[agent] = await response.json();


### PR DESCRIPTION
## Summary
- move `Notion-Version` inside headers for agent fetch requests
- ensure fetch call uses proper comma separation

## Testing
- `node --check api/zantara.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68987b81b5348330b904f524944c233f