### PR TITLE
refactor: unify handler logging

### DIFF
--- a/api/notion-write.js
+++ b/api/notion-write.js
@@ -3,7 +3,18 @@ import { Client } from "@notionhq/client";
 const notion = new Client({ auth: process.env.NOTION_TOKEN });
 
 export default async function handler(req, res) {
+  const route = "/api/notion-write";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
+
   if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "methodCheck",
+      status: 405,
+      userIP,
+      message: "Method Not Allowed",
+    }));
     return res.status(405).json({ message: "Method Not Allowed" });
   }
 
@@ -22,9 +33,25 @@ export default async function handler(req, res) {
       },
     });
 
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "success",
+      status: 200,
+      userIP,
+      message: "Notion entry created",
+    }));
+
     return res.status(200).json({ message: "Success", data: response });
   } catch (error) {
-    console.error("Notion error:", error);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "error",
+      status: 500,
+      userIP,
+      message: `Notion error: ${error.message}`,
+    }));
     return res.status(500).json({ message: "Internal Server Error", error: error.message });
   }
 }

--- a/api/notion/callback.js
+++ b/api/notion/callback.js
@@ -2,17 +2,33 @@ import axios from 'axios';
 
 export default async function handler(req, res) {
   const { code } = req.query;
+  const route = "/api/notion/callback";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
 
   if (!code || typeof code !== 'string') {
     return res.status(400).json({ error: 'Missing or invalid `code` parameter' });
   }
 
-  console.log("🔐 ENV VARIABLES CHECK:");
+  console.log(JSON.stringify({
+    timestamp: new Date().toISOString(),
+    route,
+    action: "envCheck",
+    status: 200,
+    userIP,
+    message: "ENV VARIABLES CHECK"
+  }));
   const notionToken = process.env.NOTION_TOKEN;
   const notionDatabaseId = process.env.NOTION_DATABASE_ID;
 
   if (!notionToken || !notionDatabaseId) {
-    console.error("❌ Missing NOTION_TOKEN or NOTION_DATABASE_ID");
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "envValidation",
+      status: 500,
+      userIP,
+      message: "Missing NOTION_TOKEN or NOTION_DATABASE_ID"
+    }));
     return res.status(500).json({ error: "Missing environment variables" });
   }
 
@@ -39,11 +55,25 @@ export default async function handler(req, res) {
       }
     );
 
-    console.log("✅ Entry saved to Notion:", notionRes.data.id);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "success",
+      status: 200,
+      userIP,
+      message: `Entry saved to Notion: ${notionRes.data.id}`
+    }));
     return res.status(200).json({ success: true, notionPageId: notionRes.data.id });
 
   } catch (error) {
-    console.error("❌ Error saving to Notion:", error.response?.data || error.message);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route,
+      action: "error",
+      status: 500,
+      userIP,
+      message: `Error saving to Notion: ${error.response?.data || error.message}`
+    }));
     return res.status(500).json({ error: "Failed to save to Notion" });
   }
 }

--- a/api/zantara.js
+++ b/api/zantara.js
@@ -107,7 +107,6 @@ export default async function handler(req, res) {
         const response = await fetch(`${baseUrl}/api/${agent}`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          "Notion-Version": "2022-06-28"
           body: JSON.stringify({ prompt, requester })
         });
         results[agent] = await response.json();
@@ -128,7 +127,7 @@ export default async function handler(req, res) {
         action: "orchestrate",
         status: 200,
         userIP,
-        summary: "All agents executed"
+        message: "All agents executed"
       })
     );
 

--- a/handlers/createAgentHandler.js
+++ b/handlers/createAgentHandler.js
@@ -86,7 +86,7 @@ export function createAgentHandler(agentName) {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`,
-          "Content-Type": "application/json"
+          "Content-Type": "application/json",
           "Notion-Version": "2022-06-28"
         },
         body: JSON.stringify({
@@ -106,7 +106,7 @@ export function createAgentHandler(agentName) {
         action: "success",
         status: 200,
         userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
-        summary: "Request completed successfully"
+        message: "Request completed successfully"
       }));
 
       return res.status(200).json({
@@ -116,14 +116,13 @@ export function createAgentHandler(agentName) {
         data
       });
     } catch (error) {
-      console.error("Error fetching data from OpenAI:", error);
       console.log(JSON.stringify({
         timestamp: new Date().toISOString(),
         route: `/api/${agentName}`,
         action: "error",
         status: 500,
         userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
-        message: "Internal Server Error"
+        message: `Error fetching data from OpenAI: ${error.message}`
       }));
       return res.status(500).json({
         success: false,

--- a/handlers/testTriggerHandler.js
+++ b/handlers/testTriggerHandler.js
@@ -86,7 +86,7 @@ export async function testTriggerHandler(req, res) {
       action: "success",
       status: 200,
       userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
-      summary: "Webhook triggered"
+      message: "Webhook triggered"
     }));
     return res.status(200).json({
       success: true,
@@ -95,14 +95,13 @@ export async function testTriggerHandler(req, res) {
       data
     });
   } catch (error) {
-    console.error("Error triggering webhook:", error);
     console.log(JSON.stringify({
       timestamp: new Date().toISOString(),
       route: "/api/make/test-trigger",
       action: "error",
       status: 500,
       userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
-      message: "Internal Server Error"
+      message: `Error triggering webhook: ${error.message}`
     }));
     return res.status(500).json({
       success: false,

--- a/handlers/triggerScenarioHandler.js
+++ b/handlers/triggerScenarioHandler.js
@@ -86,7 +86,7 @@ export async function triggerScenarioHandler(req, res) {
       action: "success",
       status: 200,
       userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
-      summary: "Scenario triggered"
+      message: "Scenario triggered"
     }));
     return res.status(200).json({
       success: true,
@@ -95,14 +95,13 @@ export async function triggerScenarioHandler(req, res) {
       data
     });
   } catch (error) {
-    console.error("Error triggering scenario:", error);
     console.log(JSON.stringify({
       timestamp: new Date().toISOString(),
       route: "/api/make/trigger-scenario",
       action: "error",
       status: 500,
       userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
-      message: "Internal Server Error"
+      message: `Error triggering scenario: ${error.message}`
     }));
     return res.status(500).json({
       success: false,


### PR DESCRIPTION
## Summary
- replace console.error with structured JSON logging across handlers
- log consistent fields for success and failure routes, including notion utilities and orchestrator
- fix malformed headers for test execution

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68987b8224c4833084c2815e5593a2d3