### PR TITLE
feat: harden notion callback

### DIFF
--- a/api/notion/callback.js
+++ b/api/notion/callback.js
@@ -1,23 +1,49 @@
-import axios from 'axios';
-
 export default async function handler(req, res) {
-  const { code } = req.query;
-
-  if (!code || typeof code !== 'string') {
-    return res.status(400).json({ error: 'Missing or invalid `code` parameter' });
+  if (req.method !== "POST") {
+    return res.status(405).json({ success: false, error: "Method Not Allowed" });
   }
 
-  console.log("🔐 ENV VARIABLES CHECK:");
+  // This endpoint only interacts with Notion and does not require OPENAI_API_KEY.
+  const userIP = req.headers["x-forwarded-for"] || req.socket.remoteAddress;
+
+  const { code } = req.body || {};
+
+  if (!code || typeof code !== "string") {
+    console.error(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion/callback",
+        action: "validateBody",
+        status: 400,
+        userIP,
+        error: "Missing or invalid `code` parameter"
+      })
+    );
+    return res
+      .status(400)
+      .json({ success: false, error: "Missing or invalid `code` parameter" });
+  }
+
   const notionToken = process.env.NOTION_TOKEN;
   const notionDatabaseId = process.env.NOTION_DATABASE_ID;
 
   if (!notionToken || !notionDatabaseId) {
-    console.error("❌ Missing NOTION_TOKEN or NOTION_DATABASE_ID");
-    return res.status(500).json({ error: "Missing environment variables" });
+    console.error(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion/callback",
+        action: "envCheck",
+        status: 500,
+        userIP,
+        error: "Missing NOTION_TOKEN or NOTION_DATABASE_ID"
+      })
+    );
+    return res
+      .status(500)
+      .json({ success: false, error: "Missing environment variables" });
   }
 
   try {
-    // 🔄 Optional: trasformazione del codice in contenuto Notion
     const newEntry = {
       parent: { database_id: notionDatabaseId },
       properties: {
@@ -27,23 +53,58 @@ export default async function handler(req, res) {
       }
     };
 
-    const notionRes = await axios.post(
-      'https://api.notion.com/v1/pages',
-      newEntry,
-      {
-        headers: {
-          'Authorization': `Bearer ${notionToken}`,
-          'Content-Type': 'application/json',
-          'Notion-Version': '2022-06-28'
-        }
-      }
+    const response = await fetch("https://api.notion.com/v1/pages", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${notionToken}`,
+        "Content-Type": "application/json",
+        "Notion-Version": "2022-06-28"
+      },
+      body: JSON.stringify(newEntry)
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      console.error(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          route: "/api/notion/callback",
+          action: "notionCreate",
+          status: response.status,
+          userIP,
+          error: data
+        })
+      );
+      return res
+        .status(response.status)
+        .json({ success: false, error: "Failed to save to Notion" });
+    }
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion/callback",
+        action: "notionCreate",
+        status: 200,
+        userIP,
+        notionPageId: data.id
+      })
     );
-
-    console.log("✅ Entry saved to Notion:", notionRes.data.id);
-    return res.status(200).json({ success: true, notionPageId: notionRes.data.id });
-
+    return res.status(200).json({ success: true, data: { notionPageId: data.id } });
   } catch (error) {
-    console.error("❌ Error saving to Notion:", error.response?.data || error.message);
-    return res.status(500).json({ error: "Failed to save to Notion" });
+    console.error(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/api/notion/callback",
+        action: "notionCreate",
+        status: 500,
+        userIP,
+        error: error.message
+      })
+    );
+    return res
+      .status(500)
+      .json({ success: false, error: "Failed to save to Notion" });
   }
 }


### PR DESCRIPTION
## Summary
- enforce POST method and document missing OPENAI key
- add JSON logging and env var validation for Notion callback
- refactor Notion request to native fetch

## Testing
- `npx -y vitest run` *(fails: Cannot find package 'node-mocks-http')*

------
https://chatgpt.com/codex/tasks/task_e_68987b83e12c8330a9b4fc14099e5145