### PR TITLE
feat: require Make API token via env

### DIFF
--- a/Readme final
+++ b/Readme final
@@ -75,4 +75,12 @@
 
 ---
 
+## 🌐 Environment Variables
+| Variabile | Descrizione |
+|-----------|-------------|
+| `OPENAI_API_KEY` | Chiave per accedere all'API di OpenAI. Deve essere definita nell'ambiente di deployment. |
+| `MAKE_API_TOKEN` | Token per l'integrazione con Make.com. Deve essere definito nell'ambiente di deployment. |
+
+---
+
 > Documento redatto per garantire coerenza, efficienza e intelligenza nello sviluppo AI-centric di ZANTARA.

--- a/constants/make.js
+++ b/constants/make.js
@@ -1,1 +1,4 @@
-export const DEFAULT_MAKE_API_TOKEN = "44d53bf9-799a-4e41-8b2f-3585fa2b7bfd";
+export const DEFAULT_MAKE_API_TOKEN = process.env.MAKE_API_TOKEN;
+if (!DEFAULT_MAKE_API_TOKEN) {
+  throw new Error("MAKE_API_TOKEN is not defined");
+}


### PR DESCRIPTION
## Summary
- replace hardcoded Make API token with environment variable and error if missing
- document MAKE_API_TOKEN requirement in deployment rules

## Testing
- `npm test` *(fails: Missing script "test")*
- `MAKE_API_TOKEN=make-test npx vitest run` *(fails: Parse failure in createAgentHandler.js and zantara.js)*

------
https://chatgpt.com/codex/tasks/task_e_689898538ef0833092f138784c1eb6e7