### PR TITLE
refactor: use structured error logging

### DIFF
--- a/handlers/createAgentHandler.js
+++ b/handlers/createAgentHandler.js
@@ -116,14 +116,13 @@ export function createAgentHandler(agentName) {
         data
       });
     } catch (error) {
-      console.error("Error fetching data from OpenAI:", error);
       console.log(JSON.stringify({
+        level: "error",
         timestamp: new Date().toISOString(),
         route: `/api/${agentName}`,
-        action: "error",
-        status: 500,
-        userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
-        message: "Internal Server Error"
+        context: "openaiRequest",
+        message: error.message,
+        stack: error.stack
       }));
       return res.status(500).json({
         success: false,


### PR DESCRIPTION
## Summary
- replace console.error with structured JSON logging in createAgentHandler's catch block

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689898552a98833095061572557b47c8