### PR TITLE
refactor notion callback logging and POST validation

### DIFF
--- a/api/notion/callback.js
+++ b/api/notion/callback.js
@@ -1,23 +1,43 @@
-import axios from 'axios';
-
 export default async function handler(req, res) {
-  const { code } = req.query;
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
 
-  if (!code || typeof code !== 'string') {
+  const { code } = req.query;
+  if (!code || typeof code !== "string") {
     return res.status(400).json({ error: 'Missing or invalid `code` parameter' });
   }
 
-  console.log("🔐 ENV VARIABLES CHECK:");
+  const log = (level, context, message) => {
+    const entry = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      level,
+      context,
+      message
+    });
+    if (level === 'error') {
+      console.error(entry);
+    } else {
+      console.log(entry);
+    }
+  };
+
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (!openaiKey) {
+    log('error', 'api/notion/callback', 'Missing OpenAI API Key');
+    return res.status(500).json({ error: 'Missing OpenAI API Key' });
+  }
+
+  log('info', 'api/notion/callback', 'Environment variables check');
   const notionToken = process.env.NOTION_TOKEN;
   const notionDatabaseId = process.env.NOTION_DATABASE_ID;
 
   if (!notionToken || !notionDatabaseId) {
-    console.error("❌ Missing NOTION_TOKEN or NOTION_DATABASE_ID");
-    return res.status(500).json({ error: "Missing environment variables" });
+    log('error', 'api/notion/callback', 'Missing NOTION_TOKEN or NOTION_DATABASE_ID');
+    return res.status(500).json({ error: 'Missing environment variables' });
   }
 
   try {
-    // 🔄 Optional: trasformazione del codice in contenuto Notion
     const newEntry = {
       parent: { database_id: notionDatabaseId },
       properties: {
@@ -27,23 +47,27 @@ export default async function handler(req, res) {
       }
     };
 
-    const notionRes = await axios.post(
-      'https://api.notion.com/v1/pages',
-      newEntry,
-      {
-        headers: {
-          'Authorization': `Bearer ${notionToken}`,
-          'Content-Type': 'application/json',
-          'Notion-Version': '2022-06-28'
-        }
-      }
-    );
+    const response = await fetch('https://api.notion.com/v1/pages', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${notionToken}`,
+        'Content-Type': 'application/json',
+        'Notion-Version': '2022-06-28'
+      },
+      body: JSON.stringify(newEntry)
+    });
 
-    console.log("✅ Entry saved to Notion:", notionRes.data.id);
-    return res.status(200).json({ success: true, notionPageId: notionRes.data.id });
+    const data = await response.json();
 
+    if (!response.ok) {
+      log('error', 'api/notion/callback', `Notion API error: ${JSON.stringify(data)}`);
+      return res.status(500).json({ error: 'Failed to save to Notion' });
+    }
+
+    log('info', 'api/notion/callback', `Entry saved to Notion: ${data.id}`);
+    return res.status(200).json({ ok: true });
   } catch (error) {
-    console.error("❌ Error saving to Notion:", error.response?.data || error.message);
-    return res.status(500).json({ error: "Failed to save to Notion" });
+    log('error', 'api/notion/callback', `Error saving to Notion: ${error.message}`);
+    return res.status(500).json({ error: 'Failed to save to Notion' });
   }
 }


### PR DESCRIPTION
## Summary
- enforce POST method for Notion callback and verify OpenAI key
- replace axios with native fetch and structured JSON logging
- respond with `{ ok: true }` on success

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689898569d888330a47409feccbeaac0