### PR TITLE
fix headers in createAgentHandler

### DIFF
--- a/handlers/createAgentHandler.js
+++ b/handlers/createAgentHandler.js
@@ -86,8 +86,7 @@ export function createAgentHandler(agentName) {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`,
-          "Content-Type": "application/json"
-          "Notion-Version": "2022-06-28"
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           model: "gpt-4o-mini",


### PR DESCRIPTION
## Summary
- add missing comma in `createAgentHandler` fetch headers
- remove unused `Notion-Version` header

## Testing
- `node --check handlers/createAgentHandler.js`
- `npx vitest run` *(fails: Parse failure in api/zantara.js)*

------
https://chatgpt.com/codex/tasks/task_e_68989a5d898c83308dbff72a735ff5b6