### PR TITLE
Add request timing to tests

### DIFF
--- a/tests/createAgentHandler.test.js
+++ b/tests/createAgentHandler.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import httpMocks from "node-mocks-http";
 import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { timedRequest } from "./utils/requestTimer.js";
 
 const handler = createAgentHandler("Test Agent");
 
@@ -12,7 +13,7 @@ describe("createAgentHandler", () => {
   it("returns 405 for non-POST", async () => {
     const req = httpMocks.createRequest({ method: "GET" });
     const res = httpMocks.createResponse();
-    await handler(req, res);
+    await timedRequest("createAgent", handler, req, res);
     expect(res.statusCode).toBe(405);
   });
 
@@ -20,21 +21,21 @@ describe("createAgentHandler", () => {
     delete process.env.OPENAI_API_KEY;
     const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
     const res = httpMocks.createResponse();
-    await handler(req, res);
+    await timedRequest("createAgent", handler, req, res);
     expect(res.statusCode).toBe(500);
   });
 
   it("returns 400 when prompt missing", async () => {
     const req = httpMocks.createRequest({ method: "POST" });
     const res = httpMocks.createResponse();
-    await handler(req, res);
+    await timedRequest("createAgent", handler, req, res);
     expect(res.statusCode).toBe(400);
   });
 
   it("returns 403 for blocked requester", async () => {
     const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi", requester: "Ruslantara" } });
     const res = httpMocks.createResponse();
-    await handler(req, res);
+    await timedRequest("createAgent", handler, req, res);
     expect(res.statusCode).toBe(403);
   });
 
@@ -44,7 +45,7 @@ describe("createAgentHandler", () => {
     });
     const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
     const res = httpMocks.createResponse();
-    await handler(req, res);
+    await timedRequest("createAgent", handler, req, res);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res._getData()).success).toBe(true);
   });

--- a/tests/makeTrigger.test.js
+++ b/tests/makeTrigger.test.js
@@ -1,19 +1,20 @@
 import { describe, it, expect, vi } from "vitest";
 import { triggerMakeWebhook } from "../lib/makeTrigger.js";
+import { timedCall } from "./utils/requestTimer.js";
 
 describe("ZANTARA > triggerMakeWebhook", () => {
   it("should send default payload to Make webhook", async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({}) });
-    const result = await triggerMakeWebhook();
+    const result = await timedCall("triggerMakeWebhook", () => triggerMakeWebhook());
     expect(result).toBeDefined(); // may be empty object
   });
 
   it("should send custom data in payload", async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({}) });
-    const result = await triggerMakeWebhook({
+    const result = await timedCall("triggerMakeWebhook", () => triggerMakeWebhook({
       module: "UnitTest",
       status: "OK",
-    });
+    }));
     expect(result).toBeDefined();
   });
 
@@ -22,7 +23,7 @@ describe("ZANTARA > triggerMakeWebhook", () => {
     const originalURL = global.fetch;
     global.fetch = () => Promise.resolve({ ok: false, status: 400, text: () => "Bad Request" });
 
-    await expect(triggerMakeWebhook()).rejects.toThrow("Make webhook error");
+    await expect(timedCall("triggerMakeWebhook", () => triggerMakeWebhook())).rejects.toThrow("Make webhook error");
 
     global.fetch = originalURL;
   });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,8 @@
+import { afterAll } from 'vitest';
+import { results } from './utils/requestTimer.js';
+import { writeFileSync } from 'node:fs';
+
+afterAll(() => {
+  console.table(results);
+  writeFileSync('request-times.json', JSON.stringify(results, null, 2));
+});

--- a/tests/testTriggerHandler.test.js
+++ b/tests/testTriggerHandler.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import httpMocks from "node-mocks-http";
 import { testTriggerHandler } from "../handlers/testTriggerHandler.js";
+import { timedRequest } from "./utils/requestTimer.js";
 
 beforeEach(() => {
   process.env.OPENAI_API_KEY = "test";
@@ -11,14 +12,14 @@ describe("testTriggerHandler", () => {
   it("returns 405 for non-POST", async () => {
     const req = httpMocks.createRequest({ method: "GET" });
     const res = httpMocks.createResponse();
-    await testTriggerHandler(req, res);
+    await timedRequest("testTrigger", testTriggerHandler, req, res);
     expect(res.statusCode).toBe(405);
   });
 
   it("returns 400 when fields missing", async () => {
     const req = httpMocks.createRequest({ method: "POST" });
     const res = httpMocks.createResponse();
-    await testTriggerHandler(req, res);
+    await timedRequest("testTrigger", testTriggerHandler, req, res);
     expect(res.statusCode).toBe(400);
   });
 
@@ -26,7 +27,7 @@ describe("testTriggerHandler", () => {
     global.fetch = vi.fn().mockResolvedValue({ json: () => Promise.resolve({ result: "ok" }) });
     const req = httpMocks.createRequest({ method: "POST", body: { webhook_url: "url", payload: {} } });
     const res = httpMocks.createResponse();
-    await testTriggerHandler(req, res);
+    await timedRequest("testTrigger", testTriggerHandler, req, res);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res._getData()).success).toBe(true);
   });

--- a/tests/utils/requestTimer.js
+++ b/tests/utils/requestTimer.js
@@ -1,0 +1,28 @@
+import { performance } from 'node:perf_hooks';
+
+export const results = [];
+
+export async function timedRequest(endpoint, handler, req, res) {
+  const start = performance.now();
+  try {
+    await handler(req, res);
+  } finally {
+    const ms = performance.now() - start;
+    results.push({ endpoint, status: res.statusCode, timeMs: ms });
+  }
+}
+
+export async function timedCall(endpoint, fn) {
+  const start = performance.now();
+  try {
+    const result = await fn();
+    const ms = performance.now() - start;
+    const status = result && typeof result.status === "number" ? result.status : undefined;
+    results.push({ endpoint, status, timeMs: ms });
+    return result;
+  } catch (err) {
+    const ms = performance.now() - start;
+    results.push({ endpoint, status: undefined, timeMs: ms });
+    throw err;
+  }
+}

--- a/tests/zantara.test.js
+++ b/tests/zantara.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import httpMocks from "node-mocks-http";
 import handler from "../api/zantara.js";
+import { timedRequest } from "./utils/requestTimer.js";
 
 const agents = [
   "antonelloDaily",
@@ -22,7 +23,7 @@ describe("Zantara orchestrator", () => {
   it("returns 405 for non-POST", async () => {
     const req = httpMocks.createRequest({ method: "GET" });
     const res = httpMocks.createResponse();
-    await handler(req, res);
+    await timedRequest("/api/zantara", handler, req, res);
     expect(res.statusCode).toBe(405);
   });
 
@@ -30,21 +31,21 @@ describe("Zantara orchestrator", () => {
     delete process.env.OPENAI_API_KEY;
     const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
     const res = httpMocks.createResponse();
-    await handler(req, res);
+    await timedRequest("/api/zantara", handler, req, res);
     expect(res.statusCode).toBe(500);
   });
 
   it("returns 400 when prompt missing", async () => {
     const req = httpMocks.createRequest({ method: "POST" });
     const res = httpMocks.createResponse();
-    await handler(req, res);
+    await timedRequest("/api/zantara", handler, req, res);
     expect(res.statusCode).toBe(400);
   });
 
   it("returns 403 for blocked requester", async () => {
     const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi", requester: "Ruslantara" } });
     const res = httpMocks.createResponse();
-    await handler(req, res);
+    await timedRequest("/api/zantara", handler, req, res);
     expect(res.statusCode).toBe(403);
   });
 
@@ -56,7 +57,7 @@ describe("Zantara orchestrator", () => {
     const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi", requester: "user" } });
     const res = httpMocks.createResponse();
 
-    await handler(req, res);
+    await timedRequest("/api/zantara", handler, req, res);
 
     expect(res.statusCode).toBe(200);
     const data = JSON.parse(res._getData());

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['tests/setup.js']
+  }
+});


### PR DESCRIPTION
## Summary
- measure each test request using `performance.now`
- collect endpoint, status and duration for reporting
- output timing results at the end of test runs

## Testing
- `npx vitest run` *(fails: Parse failure: Expected ',' in createAgentHandler.js)*

------
https://chatgpt.com/codex/tasks/task_e_6898bfaf31cc833095227f453b0be650