### PR TITLE
docs: add Zion OpenAPI spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Zantara API
+
+## Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| OPENAI_API_KEY | Secret key for the OpenAI API |
+| ZION_ENDPOINT | Relative path to the Zion route (default `/api/zion`) |
+| ZION_SERVERS_URL | Base URL for the Zion server (e.g., `https://zion.example.com`) |
+| OPENAPI_PATH | Path to the OpenAPI document (`/gpt/openapi.zion.json`) |
+
+To load the OpenAPI document, export:
+
+```bash
+export OPENAPI_PATH=/gpt/openapi.zion.json
+```

--- a/gpt/openapi.zion.json
+++ b/gpt/openapi.zion.json
@@ -1,0 +1,68 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Zion API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://zion.example.com"
+    }
+  ],
+  "paths": {
+    "/api/zion": {
+      "post": {
+        "summary": "Execute Zion actions",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Action"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Action response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Action": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "description": "Name of the action to perform"
+          },
+          "parameters": {
+            "type": "object",
+            "description": "Parameters for the action"
+          }
+        },
+        "required": ["action"]
+      },
+      "ActionResponse": {
+        "type": "object",
+        "properties": {
+          "status": { "type": "string" },
+          "summary": { "type": "string" },
+          "nextStep": { "type": "string" }
+        },
+        "required": ["status", "summary"]
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "dev": "vercel dev",
-    "start": "node api/notion-write.js"
+    "dev": "OPENAPI_PATH=/gpt/openapi.zion.json vercel dev",
+    "start": "OPENAPI_PATH=/gpt/openapi.zion.json node api/notion-write.js"
   },
   "dependencies": {
     "@notionhq/client": "^2.2.4"


### PR DESCRIPTION
## Summary
- add OpenAPI schema for `/api/zion`
- document Zion endpoint variables
- expose OPENAPI_PATH in package scripts

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899b992c4e4833082efe6c6d4953d52