### PR TITLE
Add VO daily refresh handler

### DIFF
--- a/api/make/vo-daily-refresh.js
+++ b/api/make/vo-daily-refresh.js
@@ -1,0 +1,3 @@
+import { voDailyRefreshHandler } from "../../handlers/voDailyRefreshHandler.js";
+
+export default voDailyRefreshHandler;

--- a/api/zantara.js
+++ b/api/zantara.js
@@ -106,8 +106,10 @@ export default async function handler(req, res) {
       try {
         const response = await fetch(`${baseUrl}/api/${agent}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          "Notion-Version": "2022-06-28"
+          headers: {
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28",
+          },
           body: JSON.stringify({ prompt, requester })
         });
         results[agent] = await response.json();

--- a/constants/notion.js
+++ b/constants/notion.js
@@ -1,0 +1,6 @@
+export function buildVoDailyRefreshPayload(databaseId) {
+  return {
+    action: "notion.query_database",
+    database_id: databaseId,
+  };
+}

--- a/handlers/createAgentHandler.js
+++ b/handlers/createAgentHandler.js
@@ -86,8 +86,8 @@ export function createAgentHandler(agentName) {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`,
-          "Content-Type": "application/json"
-          "Notion-Version": "2022-06-28"
+          "Content-Type": "application/json",
+          "Notion-Version": "2022-06-28",
         },
         body: JSON.stringify({
           model: "gpt-4o-mini",

--- a/handlers/voDailyRefreshHandler.js
+++ b/handlers/voDailyRefreshHandler.js
@@ -1,0 +1,121 @@
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+import { postToWebhook } from "../helpers/postToWebhook.js";
+import { buildVoDailyRefreshPayload } from "../constants/notion.js";
+
+export async function voDailyRefreshHandler(req, res) {
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "methodCheck",
+      status: 405,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "keyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { webhook_url, log_url, requester } = req.body || {};
+
+  if (!webhook_url || !log_url) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "validation",
+      status: 400,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Missing webhook_url or log_url"
+    }));
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing webhook_url or log_url",
+      error: "Missing webhook_url or log_url",
+      nextStep: "Provide webhook_url and log_url"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "blockedRequester",
+      status: 403,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Requester is blocked"
+    }));
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  const databaseId = process.env.VO_DATABASE_ID || "";
+  const notionPayload = buildVoDailyRefreshPayload(databaseId);
+  const payload = { route: "VO-DAILY-REFRESH", notion: notionPayload };
+
+  try {
+    const data = await postToWebhook(webhook_url, payload);
+    await postToWebhook(log_url, { route: "ZION • Logs", result: data });
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "success",
+      status: 200,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      summary: "Query dispatched"
+    }));
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Query dispatched",
+      data
+    });
+  } catch (error) {
+    console.error("Error dispatching query:", error);
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "error",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Internal Server Error"
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}

--- a/tests/voDailyRefreshHandler.test.js
+++ b/tests/voDailyRefreshHandler.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { voDailyRefreshHandler } from "../handlers/voDailyRefreshHandler.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.MAKE_API_TOKEN = "make-test";
+  process.env.VO_DATABASE_ID = "db123";
+});
+
+describe("voDailyRefreshHandler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await voDailyRefreshHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 400 when fields missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await voDailyRefreshHandler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 200 on success", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ json: () => Promise.resolve({ result: "ok" }) });
+    const req = httpMocks.createRequest({ method: "POST", body: { webhook_url: "url", log_url: "log" } });
+    const res = httpMocks.createResponse();
+    await voDailyRefreshHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Make route VO-DAILY-REFRESH to send Notion query payloads and log results
- provide Notion payload builder for the daily refresh
- fix header formatting in existing agent code

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6899b993e0508330a407414b1e1c568c