### PR TITLE
fix: clean OpenAI headers

### DIFF
--- a/api/zantara.js
+++ b/api/zantara.js
@@ -107,7 +107,6 @@ export default async function handler(req, res) {
         const response = await fetch(`${baseUrl}/api/${agent}`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          "Notion-Version": "2022-06-28"
           body: JSON.stringify({ prompt, requester })
         });
         results[agent] = await response.json();

--- a/handlers/createAgentHandler.js
+++ b/handlers/createAgentHandler.js
@@ -86,8 +86,7 @@ export function createAgentHandler(agentName) {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`,
-          "Content-Type": "application/json"
-          "Notion-Version": "2022-06-28"
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           model: "gpt-4o-mini",


### PR DESCRIPTION
## Summary
- fix OpenAI request headers in `createAgentHandler` by removing Notion-specific header
- clean up orchestrator fetch headers in `api/zantara`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6899b9984d6883308b80a5f82e31d0d0