### PR TITLE
fix: add Notion version header

### DIFF
--- a/api/zantara.js
+++ b/api/zantara.js
@@ -106,8 +106,7 @@ export default async function handler(req, res) {
       try {
         const response = await fetch(`${baseUrl}/api/${agent}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          "Notion-Version": "2022-06-28"
+          headers: { "Content-Type": "application/json", "Notion-Version": "2022-06-28" },
           body: JSON.stringify({ prompt, requester })
         });
         results[agent] = await response.json();


### PR DESCRIPTION
## Summary
- include Notion API version in orchestrator agent calls

## Testing
- `npx vitest run` *(fails: RollupError: Parse failure in handlers/createAgentHandler.js)*

------
https://chatgpt.com/codex/tasks/task_e_6899b9995580833085b1db02d2a24b4f