### PR TITLE
Add Notion database creation API and tests

### DIFF
--- a/api/notion-database-create.js
+++ b/api/notion-database-create.js
@@ -1,0 +1,156 @@
+import { Client } from "@notionhq/client";
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+
+export default async function handler(req, res) {
+  const route = "/api/notion-database-create";
+  const userIP = req.headers["x-forwarded-for"] || req.socket?.remoteAddress;
+
+  if (req.method !== "POST") {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "methodCheck",
+        status: 405,
+        userIP,
+        message: "Method Not Allowed"
+      })
+    );
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "keyValidation",
+        status: 500,
+        userIP,
+        message: err.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  if (!process.env.NOTION_TOKEN) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "tokenValidation",
+        status: 500,
+        userIP,
+        message: "Missing Notion token"
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Missing Notion token",
+      error: "Missing Notion token",
+      nextStep: "Set NOTION_TOKEN in environment"
+    });
+  }
+
+  const { parentPageId, title, properties, requester } = req.body || {};
+
+  if (!parentPageId || !title || !properties) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "payloadValidation",
+        status: 400,
+        userIP,
+        message: "Missing required fields"
+      })
+    );
+    return res.status(400).json({
+      success: false,
+      status: 400,
+      summary: "Missing required fields",
+      error: "Missing parentPageId, title, or properties",
+      nextStep: "Include parentPageId, title, and properties in JSON body"
+    });
+  }
+
+  if (isBlockedRequester(requester)) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "blockedRequester",
+        status: 403,
+        userIP,
+        message: "Requester is blocked"
+      })
+    );
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  try {
+    const database = await notion.databases.create({
+      parent: { type: "page_id", page_id: parentPageId },
+      title: [{ type: "text", text: { content: title } }],
+      properties
+    });
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "createDatabase",
+        status: 200,
+        userIP,
+        summary: "Database created"
+      })
+    );
+
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "Database created",
+      data: database
+    });
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route,
+        action: "error",
+        status: 500,
+        userIP,
+        message: error.message
+      })
+    );
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Failed to create database",
+      error: error.message
+    });
+  }
+}

--- a/helpers/checkBlockedRequester.js
+++ b/helpers/checkBlockedRequester.js
@@ -1,5 +1,6 @@
-const blocked = ["Ruslantara", "Deanto"];
+const blocked = ["ruslantara", "deanto"];
 
 export function isBlockedRequester(name = "") {
-  return blocked.includes(name);
+  const lower = name.toLowerCase();
+  return blocked.some((b) => lower.includes(b));
 }

--- a/tests/notion-database-create.test.js
+++ b/tests/notion-database-create.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+
+vi.mock("@notionhq/client", () => {
+  const createMock = vi.fn();
+  return {
+    Client: vi.fn().mockImplementation(() => ({
+      databases: { create: createMock }
+    })),
+    __esModule: true,
+    createMock
+  };
+});
+
+import handler from "../api/notion-database-create.js";
+import { createMock } from "@notionhq/client";
+
+describe("Notion database create handler", () => {
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "test";
+    process.env.NOTION_TOKEN = "test";
+    createMock.mockReset();
+    createMock.mockResolvedValue({ id: "db" });
+  });
+
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when OPENAI_API_KEY missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST", body: { parentPageId: "p", title: "t", properties: {} } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 500 when NOTION_TOKEN missing", async () => {
+    delete process.env.NOTION_TOKEN;
+    const req = httpMocks.createRequest({ method: "POST", body: { parentPageId: "p", title: "t", properties: {} } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 400 when required fields missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: {} });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { parentPageId: "p", title: "t", properties: {}, requester: "Ruslantara" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 200 and data on success", async () => {
+    const body = { parentPageId: "p", title: "Test", properties: {}, requester: "user" };
+    const req = httpMocks.createRequest({ method: "POST", body });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    const data = JSON.parse(res._getData());
+    expect(data.success).toBe(true);
+    expect(createMock).toHaveBeenCalledWith({
+      parent: { type: "page_id", page_id: body.parentPageId },
+      title: [{ type: "text", text: { content: body.title } }],
+      properties: body.properties
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- create Notion database endpoint with method, environment, and payload validation
- update requester block helper for substring case-insensitive matches
- add unit tests covering success and error paths

## Testing
- `npx vitest tests/notion-database-create.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689a0d7758908330979637c836fe1e89