### PR TITLE
Fix Notion header placement in agent orchestrator

### DIFF
--- a/api/zantara.js
+++ b/api/zantara.js
@@ -106,8 +106,10 @@ export default async function handler(req, res) {
       try {
         const response = await fetch(`${baseUrl}/api/${agent}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          "Notion-Version": "2022-06-28"
+          headers: {
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28"
+          },
           body: JSON.stringify({ prompt, requester })
         });
         results[agent] = await response.json();


### PR DESCRIPTION
## Summary
- Place Notion-Version inside fetch headers for each agent call
- Ensure fetch options are properly comma-delimited

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a12113bc883309545d48aba3feff0