### PR TITLE
Fix header placement in zantara agent fetch

### DIFF
--- a/api/zantara.js
+++ b/api/zantara.js
@@ -106,9 +106,11 @@ export default async function handler(req, res) {
       try {
         const response = await fetch(`${baseUrl}/api/${agent}`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          "Notion-Version": "2022-06-28"
-          body: JSON.stringify({ prompt, requester })
+          headers: {
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28",
+          },
+          body: JSON.stringify({ prompt, requester }),
         });
         results[agent] = await response.json();
       } catch (err) {


### PR DESCRIPTION
## Summary
- fix fetch request to include Notion-Version in headers object

## Testing
- `npx vitest run` *(fails: RollupError: Parse failure: Expected ',', got 'string literal (Notion-Version, "Notion-Version")')*


------
https://chatgpt.com/codex/tasks/task_e_689a5ba8ec7883309132357a8a9cd9be