### PR TITLE
chore: tidy OpenAI request headers

### DIFF
--- a/handlers/createAgentHandler.js
+++ b/handlers/createAgentHandler.js
@@ -87,7 +87,6 @@ export function createAgentHandler(agentName) {
         headers: {
           "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`,
           "Content-Type": "application/json",
-          "Notion-Version": "2022-06-28",
         },
         body: JSON.stringify({
           model: "gpt-4o-mini",


### PR DESCRIPTION
## Summary
- remove unused Notion header from OpenAI request
- keep trailing comma style after Content-Type header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c6e4b0020833088dbc912376695b7