### PR TITLE
feat: add VO daily refresh to ZION

### DIFF
--- a/api/make/vo-daily-refresh.js
+++ b/api/make/vo-daily-refresh.js
@@ -1,0 +1,2 @@
+import { voDailyRefreshHandler } from "../../handlers/voDailyRefreshHandler.js";
+export default voDailyRefreshHandler;

--- a/constants/vo.js
+++ b/constants/vo.js
@@ -1,0 +1,4 @@
+export const VO_DAILY_REFRESH_PAYLOAD = {
+  action: "notion.query_database",
+  database_id: "placeholder-db-id"
+};

--- a/constants/zion.js
+++ b/constants/zion.js
@@ -1,0 +1,3 @@
+export const DEFAULT_ZION_API_TOKEN = "zion-default-token";
+export const DEFAULT_ZION_URL = "https://zion.example.com/query";
+export const DEFAULT_ZION_LOGS_URL = "https://zion.example.com/logs";

--- a/handlers/voDailyRefreshHandler.js
+++ b/handlers/voDailyRefreshHandler.js
@@ -1,0 +1,101 @@
+import { validateOpenAIKey } from "../helpers/validateOpenAIKey.js";
+import { isBlockedRequester } from "../helpers/checkBlockedRequester.js";
+import { postToZion } from "../helpers/postToZion.js";
+import { VO_DAILY_REFRESH_PAYLOAD } from "../constants/vo.js";
+import { DEFAULT_ZION_URL, DEFAULT_ZION_LOGS_URL } from "../constants/zion.js";
+
+export async function voDailyRefreshHandler(req, res) {
+  if (req.method !== "POST") {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "methodCheck",
+      status: 405,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Method Not Allowed"
+    }));
+    return res.status(405).json({
+      success: false,
+      status: 405,
+      summary: "Method Not Allowed",
+      error: "Method Not Allowed",
+      nextStep: "Send a POST request"
+    });
+  }
+
+  try {
+    validateOpenAIKey();
+  } catch (err) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "keyValidation",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: err.message
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: err.message,
+      error: err.message,
+      nextStep: "Set OPENAI_API_KEY in environment"
+    });
+  }
+
+  const { requester } = req.body || {};
+  if (isBlockedRequester(requester)) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "blockedRequester",
+      status: 403,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Requester is blocked"
+    }));
+    return res.status(403).json({
+      success: false,
+      status: 403,
+      summary: "Requester is blocked",
+      error: "Access denied"
+    });
+  }
+
+  const zionUrl = process.env.ZION_URL || DEFAULT_ZION_URL;
+  const zionLogsUrl = process.env.ZION_LOGS_URL || DEFAULT_ZION_LOGS_URL;
+
+  try {
+    const data = await postToZion(zionUrl, VO_DAILY_REFRESH_PAYLOAD);
+    await postToZion(zionLogsUrl, { route: "VO-DAILY-REFRESH", data });
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "success",
+      status: 200,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      summary: "ZION query executed"
+    }));
+    return res.status(200).json({
+      success: true,
+      status: 200,
+      summary: "ZION query executed",
+      data
+    });
+  } catch (error) {
+    console.log(JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/make/vo-daily-refresh",
+      action: "error",
+      status: 500,
+      userIP: req.headers["x-forwarded-for"] || req.socket?.remoteAddress,
+      message: "Internal Server Error"
+    }));
+    return res.status(500).json({
+      success: false,
+      status: 500,
+      summary: "Internal Server Error",
+      error: "Internal Server Error",
+      nextStep: "Check server logs and retry"
+    });
+  }
+}

--- a/helpers/postToZion.js
+++ b/helpers/postToZion.js
@@ -1,0 +1,19 @@
+import { DEFAULT_ZION_API_TOKEN } from "../constants/zion.js";
+
+export async function postToZion(url, payload) {
+  const token = process.env.ZION_API_TOKEN || DEFAULT_ZION_API_TOKEN;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}

--- a/tests/voDailyRefreshHandler.test.js
+++ b/tests/voDailyRefreshHandler.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import { voDailyRefreshHandler } from "../handlers/voDailyRefreshHandler.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+  process.env.ZION_API_TOKEN = "zion-test";
+  process.env.ZION_URL = "https://zion.example.com/query";
+  process.env.ZION_LOGS_URL = "https://zion.example.com/logs";
+  vi.resetAllMocks();
+});
+
+describe("voDailyRefreshHandler", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await voDailyRefreshHandler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 500 when API key missing", async () => {
+    delete process.env.OPENAI_API_KEY;
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await voDailyRefreshHandler(req, res);
+    expect(res.statusCode).toBe(500);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { requester: "Ruslantara" } });
+    const res = httpMocks.createResponse();
+    await voDailyRefreshHandler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("returns 200 on success", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ json: () => Promise.resolve({ result: "ok" }) });
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await voDailyRefreshHandler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res._getData()).success).toBe(true);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add constants and helper for posting to ZION
- implement VO daily refresh handler and route
- log query results to ZION logs and test handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c6e452de48330924956fecc7d54c9