### PR TITLE
feat: add Zantara Pro Power agent

### DIFF
--- a/Readme final
+++ b/Readme final
@@ -76,3 +76,30 @@
 ---
 
 > Documento redatto per garantire coerenza, efficienza e intelligenza nello sviluppo AI-centric di ZANTARA.
+
+## Zantara Pro Power Endpoint
+
+### Route
+`POST /api/zantaraProPower`
+
+### Request Body
+```
+{
+  "prompt": "Your prompt here",
+  "requester": "optional"
+}
+```
+
+### Response
+```
+{
+  "success": true,
+  "status": 200,
+  "summary": "Request completed successfully",
+  "data": {
+    "choices": []
+  }
+}
+```
+
+Blocked requesters "Ruslantara" and "Deanto" will receive a 403 response.

--- a/api/zantara.js
+++ b/api/zantara.js
@@ -8,7 +8,8 @@ const agents = [
   "setupMaster",
   "taxGenius",
   "theLegalArchitect",
-  "visaOracle"
+  "visaOracle",
+  "zantaraProPower"
 ];
 
 export default async function handler(req, res) {

--- a/api/zantaraProPower.js
+++ b/api/zantaraProPower.js
@@ -1,0 +1,6 @@
+import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { writeAgentResult } from "../helpers/notionLogger.js";
+
+export default createAgentHandler("Zantara Pro Power", async (prompt, data) => {
+  await writeAgentResult("zantaraProPower", prompt, data);
+});

--- a/tests/zantara.test.js
+++ b/tests/zantara.test.js
@@ -9,7 +9,8 @@ const agents = [
   "setupMaster",
   "taxGenius",
   "theLegalArchitect",
-  "visaOracle"
+  "visaOracle",
+  "zantaraProPower"
 ];
 
 beforeEach(() => {

--- a/tests/zantaraProPower.test.js
+++ b/tests/zantaraProPower.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/zantaraProPower.js";
+
+beforeEach(() => {
+  process.env.OPENAI_API_KEY = "test";
+});
+
+describe("zantaraProPower endpoint", () => {
+  it("returns 405 for non-POST", async () => {
+    const req = httpMocks.createRequest({ method: "GET" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it("returns 400 when prompt missing", async () => {
+    const req = httpMocks.createRequest({ method: "POST" });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns 403 for blocked requester", async () => {
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi", requester: "Ruslantara" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- add Zantara Pro Power endpoint and write results to Notion
- orchestrate new agent with existing zantara handler
- document endpoint and cover basic request validation in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0591af1483308ef4e3619d844874