### PR TITLE
Integrate Pro Power API forwarding

### DIFF
--- a/Readme final
+++ b/Readme final
@@ -76,3 +76,39 @@
 ---
 
 > Documento redatto per garantire coerenza, efficienza e intelligenza nello sviluppo AI-centric di ZANTARA.
+
+---
+
+## 🌐 Environment Variables
+
+| Variable | Description |
+|---|---|
+| `OPENAI_API_KEY` | Secret key for accessing the OpenAI API. Must be defined in your environment (e.g., Vercel, .env file). |
+| `PRO_POWER_API_URL` | Endpoint for sending `{ prompt, result }` payloads to the Pro Power service. |
+
+## ⚡ Example: /api/zantaraProPower
+
+**Request**
+```bash
+POST /api/zantaraProPower
+Content-Type: application/json
+
+{ "prompt": "Explain quantum computing" }
+```
+
+**Response**
+```json
+{
+  "success": true,
+  "status": 200,
+  "summary": "Request completed successfully",
+  "data": {
+    "proPower": {
+      "success": true,
+      "status": 200,
+      "summary": "Pro Power API call succeeded",
+      "data": { "message": "processed" }
+    }
+  }
+}
+```

--- a/api/zantaraProPower.js
+++ b/api/zantaraProPower.js
@@ -1,0 +1,18 @@
+import { createAgentHandler } from "../handlers/createAgentHandler.js";
+import { postToProPowerAPI } from "../helpers/postToProPowerAPI.js";
+
+export default createAgentHandler("zantaraProPower", async (prompt, result) => {
+  const proPower = await postToProPowerAPI(prompt, result);
+
+  console.log(
+    JSON.stringify({
+      timestamp: new Date().toISOString(),
+      route: "/api/zantaraProPower",
+      action: "forwardToProPower",
+      status: proPower.status,
+      summary: proPower.summary
+    })
+  );
+
+  result.proPower = proPower;
+});

--- a/helpers/postToProPowerAPI.js
+++ b/helpers/postToProPowerAPI.js
@@ -1,0 +1,58 @@
+export async function postToProPowerAPI(prompt, result) {
+  const url = process.env.PRO_POWER_API_URL;
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({ prompt, result })
+    });
+
+    const responseData = await response.json().catch(() => ({}));
+
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/helpers/postToProPowerAPI",
+        action: "forwardToProPower",
+        status: response.status,
+        summary: response.ok
+          ? "Pro Power API call succeeded"
+          : "Pro Power API call failed"
+      })
+    );
+
+    if (!response.ok) {
+      return {
+        success: false,
+        status: response.status,
+        summary: "Pro Power API call failed",
+        error: responseData.error || "Unknown error"
+      };
+    }
+
+    return {
+      success: true,
+      status: response.status,
+      summary: "Pro Power API call succeeded",
+      data: responseData
+    };
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        route: "/helpers/postToProPowerAPI",
+        action: "forwardToProPower",
+        status: 500,
+        error: error.message
+      })
+    );
+    return {
+      success: false,
+      status: 500,
+      summary: "Pro Power API call failed",
+      error: error.message
+    };
+  }
+}

--- a/tests/zantaraProPowerAPI.test.js
+++ b/tests/zantaraProPowerAPI.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import httpMocks from "node-mocks-http";
+import handler from "../api/zantaraProPower.js";
+
+describe("zantaraProPower API", () => {
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "test";
+    process.env.PRO_POWER_API_URL = "https://propower.example.com";
+  });
+
+  it("attaches Pro Power API success result", async () => {
+    const openAIResponse = { result: "ok" };
+    const proPowerResponse = { message: "done" };
+
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve(openAIResponse) })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(proPowerResponse)
+      });
+
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+
+    const payload = JSON.parse(res._getData());
+    expect(res.statusCode).toBe(200);
+    expect(payload.data.proPower.success).toBe(true);
+    expect(payload.data.proPower.data).toEqual(proPowerResponse);
+  });
+
+  it("attaches Pro Power API error result", async () => {
+    const openAIResponse = { result: "ok" };
+    const proPowerError = { error: "fail" };
+
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve(openAIResponse) })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve(proPowerError)
+      });
+
+    const req = httpMocks.createRequest({ method: "POST", body: { prompt: "hi" } });
+    const res = httpMocks.createResponse();
+    await handler(req, res);
+
+    const payload = JSON.parse(res._getData());
+    expect(res.statusCode).toBe(200);
+    expect(payload.data.proPower.success).toBe(false);
+    expect(payload.data.proPower.error).toBe("fail");
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to send agent results to Pro Power API
- forward zantaraProPower agent outputs and log outcome
- document PRO_POWER_API_URL usage and test success/error flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0d94329c8330bd5167a18d512fe4